### PR TITLE
fix: undo log sql

### DIFF
--- a/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
+++ b/pkg/datasource/sql/undo/builder/basic_undo_log_builder.go
@@ -121,6 +121,10 @@ func (b *BasicUndoLogBuilder) traversalArgs(node ast.Node, argsIndex *[]int32) {
 			b.traversalArgs(exprs[i], argsIndex)
 		}
 		break
+	case *ast.ParenthesesExpr:
+		expr := node.(*ast.ParenthesesExpr)
+		b.traversalArgs(expr.Expr, argsIndex)
+		break
 	case *test_driver.ParamMarkerExpr:
 		*argsIndex = append(*argsIndex, int32(node.(*test_driver.ParamMarkerExpr).Order))
 		break


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Fix the problem of `MySQLUpdateUndoLogBuilder` failing to generate undo log sql.

The reason for the failure is that `BasicUndoLogBuilder.traversalArgs` ignores the processing of the `ParenthesesExpr` node when recursively traversing ast.

Solved after adding the following code:

```go
case *ast.ParenthesesExpr:
	expr := node.(*ast.ParenthesesExpr)
	b.traversalArgs(expr.Expr, argsIndex)
	break
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #593

**Special notes for your reviewer**:

Test samples for this issue have been added and all test cases have passed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```