### PR TITLE
[Refactor] Migrate StateMachineObject to client/config and unify config parsing with koanf

### DIFF
--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -20,6 +20,7 @@ package client
 import (
 	"flag"
 	"fmt"
+	"github.com/seata/seata-go/pkg/saga"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -85,24 +86,7 @@ type Config struct {
 	ServiceConfig     discovery.ServiceConfig      `yaml:"service" json:"service" koanf:"service"`
 	RegistryConfig    discovery.RegistryConfig     `yaml:"registry" json:"registry" koanf:"registry"`
 
-	SagaConfig SagaConfig `yaml:"saga" json:"saga" koanf:"saga"`
-}
-
-type SagaConfig struct {
-	StateMachine *StateMachineObject `yaml:"state-machine" json:"state-machine" koanf:"state-machine"`
-}
-
-type StateMachineObject struct {
-	Name                        string                 `json:"Name" yaml:"Name"`
-	Comment                     string                 `json:"Comment" yaml:"Comment"`
-	Version                     string                 `json:"Version" yaml:"Version"`
-	StartState                  string                 `json:"StartState" yaml:"StartState"`
-	RecoverStrategy             string                 `json:"RecoverStrategy" yaml:"RecoverStrategy"`
-	Persist                     bool                   `json:"IsPersist" yaml:"IsPersist"`
-	RetryPersistModeUpdate      bool                   `json:"IsRetryPersistModeUpdate" yaml:"IsRetryPersistModeUpdate"`
-	CompensatePersistModeUpdate bool                   `json:"IsCompensatePersistModeUpdate" yaml:"IsCompensatePersistModeUpdate"`
-	Type                        string                 `json:"Type" yaml:"Type"`
-	States                      map[string]interface{} `json:"States" yaml:"States"`
+	SagaConfig saga.Config `yaml:"saga" json:"saga" koanf:"saga"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
@@ -121,6 +105,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	c.TransportConfig.RegisterFlagsWithPrefix("transport", f)
 	c.RegistryConfig.RegisterFlagsWithPrefix("registry", f)
 	c.ServiceConfig.RegisterFlagsWithPrefix("service", f)
+	c.SagaConfig.RegisterFlagsWithPrefix("saga", f)
 }
 
 type loaderConf struct {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -84,6 +84,25 @@ type Config struct {
 	TransportConfig   remoteConfig.TransportConfig `yaml:"transport" json:"transport" koanf:"transport"`
 	ServiceConfig     discovery.ServiceConfig      `yaml:"service" json:"service" koanf:"service"`
 	RegistryConfig    discovery.RegistryConfig     `yaml:"registry" json:"registry" koanf:"registry"`
+
+	SagaConfig SagaConfig `yaml:"saga" json:"saga" koanf:"saga"`
+}
+
+type SagaConfig struct {
+	StateMachine *StateMachineObject `yaml:"state-machine" json:"state-machine" koanf:"state-machine"`
+}
+
+type StateMachineObject struct {
+	Name                        string                 `json:"Name" yaml:"Name"`
+	Comment                     string                 `json:"Comment" yaml:"Comment"`
+	Version                     string                 `json:"Version" yaml:"Version"`
+	StartState                  string                 `json:"StartState" yaml:"StartState"`
+	RecoverStrategy             string                 `json:"RecoverStrategy" yaml:"RecoverStrategy"`
+	Persist                     bool                   `json:"IsPersist" yaml:"IsPersist"`
+	RetryPersistModeUpdate      bool                   `json:"IsRetryPersistModeUpdate" yaml:"IsRetryPersistModeUpdate"`
+	CompensatePersistModeUpdate bool                   `json:"IsCompensatePersistModeUpdate" yaml:"IsCompensatePersistModeUpdate"`
+	Type                        string                 `json:"Type" yaml:"Type"`
+	States                      map[string]interface{} `json:"States" yaml:"States"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/saga/config.go
+++ b/pkg/saga/config.go
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package saga
+
+import (
+	"flag"
+
+	"github.com/seata/seata-go/pkg/saga/statemachine"
+)
+
+type Config struct {
+	StateMachine *statemachine.StateMachineObject `yaml:"state-machine" json:"state-machine" koanf:"state-machine"`
+}
+
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	if cfg.StateMachine != nil {
+		cfg.StateMachine.RegisterFlagsWithPrefix(prefix+".state-machine", f)
+	}
+}

--- a/pkg/saga/statemachine/statelang/parser/statemachine_config_parser.go
+++ b/pkg/saga/statemachine/statelang/parser/statemachine_config_parser.go
@@ -20,6 +20,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"github.com/seata/seata-go/pkg/saga/statemachine"
 	"io"
 	"os"
 
@@ -27,13 +28,11 @@ import (
 	"github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/rawbytes"
-
-	"github.com/seata/seata-go/pkg/client"
 )
 
 // ConfigParser is a general configuration parser interface, used to agree on the implementation of different types of parsers
 type ConfigParser interface {
-	Parse(configContent []byte) (*client.StateMachineObject, error)
+	Parse(configContent []byte) (*statemachine.StateMachineObject, error)
 }
 
 type JSONConfigParser struct{}
@@ -42,7 +41,7 @@ func NewJSONConfigParser() *JSONConfigParser {
 	return &JSONConfigParser{}
 }
 
-func (p *JSONConfigParser) Parse(configContent []byte) (*client.StateMachineObject, error) {
+func (p *JSONConfigParser) Parse(configContent []byte) (*statemachine.StateMachineObject, error) {
 	if configContent == nil || len(configContent) == 0 {
 		return nil, fmt.Errorf("empty JSON config content")
 	}
@@ -52,7 +51,7 @@ func (p *JSONConfigParser) Parse(configContent []byte) (*client.StateMachineObje
 		return nil, fmt.Errorf("failed to parse JSON config content: %w", err)
 	}
 
-	var stateMachineObject client.StateMachineObject
+	var stateMachineObject statemachine.StateMachineObject
 	if err := k.Unmarshal("", &stateMachineObject); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JSON config to struct: %w", err)
 	}
@@ -66,7 +65,7 @@ func NewYAMLConfigParser() *YAMLConfigParser {
 	return &YAMLConfigParser{}
 }
 
-func (p *YAMLConfigParser) Parse(configContent []byte) (*client.StateMachineObject, error) {
+func (p *YAMLConfigParser) Parse(configContent []byte) (*statemachine.StateMachineObject, error) {
 	if configContent == nil || len(configContent) == 0 {
 		return nil, fmt.Errorf("empty YAML config content")
 	}
@@ -76,7 +75,7 @@ func (p *YAMLConfigParser) Parse(configContent []byte) (*client.StateMachineObje
 		return nil, fmt.Errorf("failed to parse YAML config content: %w", err)
 	}
 
-	var stateMachineObject client.StateMachineObject
+	var stateMachineObject statemachine.StateMachineObject
 	if err := k.Unmarshal("", &stateMachineObject); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal YAML config to struct: %w", err)
 	}
@@ -130,7 +129,7 @@ func (p *StateMachineConfigParser) getParser(content []byte) (ConfigParser, erro
 	return nil, fmt.Errorf("unsupported config file format")
 }
 
-func (p *StateMachineConfigParser) Parse(content []byte) (*client.StateMachineObject, error) {
+func (p *StateMachineConfigParser) Parse(content []byte) (*statemachine.StateMachineObject, error) {
 	parser, err := p.getParser(content)
 	if err != nil {
 		return nil, err

--- a/pkg/saga/statemachine/statelang/parser/statemachine_config_parser.go
+++ b/pkg/saga/statemachine/statelang/parser/statemachine_config_parser.go
@@ -19,16 +19,21 @@ package parser
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
+
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/parsers/json"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/rawbytes"
+
+	"github.com/seata/seata-go/pkg/client"
 )
 
 // ConfigParser is a general configuration parser interface, used to agree on the implementation of different types of parsers
 type ConfigParser interface {
-	Parse(configContent []byte) (*StateMachineObject, error)
+	Parse(configContent []byte) (*client.StateMachineObject, error)
 }
 
 type JSONConfigParser struct{}
@@ -37,14 +42,19 @@ func NewJSONConfigParser() *JSONConfigParser {
 	return &JSONConfigParser{}
 }
 
-func (p *JSONConfigParser) Parse(configContent []byte) (*StateMachineObject, error) {
+func (p *JSONConfigParser) Parse(configContent []byte) (*client.StateMachineObject, error) {
 	if configContent == nil || len(configContent) == 0 {
 		return nil, fmt.Errorf("empty JSON config content")
 	}
 
-	var stateMachineObject StateMachineObject
-	if err := json.Unmarshal(configContent, &stateMachineObject); err != nil {
+	k := koanf.New(".")
+	if err := k.Load(rawbytes.Provider(configContent), json.Parser()); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON config content: %w", err)
+	}
+
+	var stateMachineObject client.StateMachineObject
+	if err := k.Unmarshal("", &stateMachineObject); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON config to struct: %w", err)
 	}
 
 	return &stateMachineObject, nil
@@ -56,14 +66,19 @@ func NewYAMLConfigParser() *YAMLConfigParser {
 	return &YAMLConfigParser{}
 }
 
-func (p *YAMLConfigParser) Parse(configContent []byte) (*StateMachineObject, error) {
+func (p *YAMLConfigParser) Parse(configContent []byte) (*client.StateMachineObject, error) {
 	if configContent == nil || len(configContent) == 0 {
 		return nil, fmt.Errorf("empty YAML config content")
 	}
 
-	var stateMachineObject StateMachineObject
-	if err := yaml.Unmarshal(configContent, &stateMachineObject); err != nil {
+	k := koanf.New(".")
+	if err := k.Load(rawbytes.Provider(configContent), yaml.Parser()); err != nil {
 		return nil, fmt.Errorf("failed to parse YAML config content: %w", err)
+	}
+
+	var stateMachineObject client.StateMachineObject
+	if err := k.Unmarshal("", &stateMachineObject); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal YAML config to struct: %w", err)
 	}
 
 	return &stateMachineObject, nil
@@ -102,35 +117,24 @@ func (p *StateMachineConfigParser) ReadConfigFile(configFilePath string) ([]byte
 }
 
 func (p *StateMachineConfigParser) getParser(content []byte) (ConfigParser, error) {
-	var obj interface{}
-	if err := json.Unmarshal(content, &obj); err == nil {
+	k := koanf.New(".")
+	if err := k.Load(rawbytes.Provider(content), json.Parser()); err == nil {
 		return NewJSONConfigParser(), nil
 	}
-	if err := yaml.Unmarshal(content, &obj); err == nil {
+
+	k = koanf.New(".")
+	if err := k.Load(rawbytes.Provider(content), yaml.Parser()); err == nil {
 		return NewYAMLConfigParser(), nil
 	}
 
 	return nil, fmt.Errorf("unsupported config file format")
 }
 
-func (p *StateMachineConfigParser) Parse(content []byte) (*StateMachineObject, error) {
+func (p *StateMachineConfigParser) Parse(content []byte) (*client.StateMachineObject, error) {
 	parser, err := p.getParser(content)
 	if err != nil {
 		return nil, err
 	}
 
 	return parser.Parse(content)
-}
-
-type StateMachineObject struct {
-	Name                        string                 `json:"Name" yaml:"Name"`
-	Comment                     string                 `json:"Comment" yaml:"Comment"`
-	Version                     string                 `json:"Version" yaml:"Version"`
-	StartState                  string                 `json:"StartState" yaml:"StartState"`
-	RecoverStrategy             string                 `json:"RecoverStrategy" yaml:"RecoverStrategy"`
-	Persist                     bool                   `json:"IsPersist" yaml:"IsPersist"`
-	RetryPersistModeUpdate      bool                   `json:"IsRetryPersistModeUpdate" yaml:"IsRetryPersistModeUpdate"`
-	CompensatePersistModeUpdate bool                   `json:"IsCompensatePersistModeUpdate" yaml:"IsCompensatePersistModeUpdate"`
-	Type                        string                 `json:"Type" yaml:"Type"`
-	States                      map[string]interface{} `json:"States" yaml:"States"`
 }

--- a/pkg/saga/statemachine/statelang/parser/statemachine_config_parser_test.go
+++ b/pkg/saga/statemachine/statelang/parser/statemachine_config_parser_test.go
@@ -18,7 +18,7 @@
 package parser
 
 import (
-	"github.com/seata/seata-go/pkg/client"
+	"github.com/seata/seata-go/pkg/saga/statemachine"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -29,7 +29,7 @@ func TestStateMachineConfigParser_Parse(t *testing.T) {
 	tests := []struct {
 		name           string
 		configFilePath string
-		expectedObject *client.StateMachineObject
+		expectedObject *statemachine.StateMachineObject
 	}{
 		{
 			name:           "JSON Simple 1",
@@ -78,13 +78,13 @@ func TestStateMachineConfigParser_Parse(t *testing.T) {
 	}
 }
 
-func GetStateMachineObject1(format string) *client.StateMachineObject {
+func GetStateMachineObject1(format string) *statemachine.StateMachineObject {
 	switch format {
 	case "json":
 	case "yaml":
 	}
 
-	return &client.StateMachineObject{
+	return &statemachine.StateMachineObject{
 		Name:       "simpleChoiceTestStateMachine",
 		Comment:    "带条件分支的测试状态机定义",
 		StartState: "FirstState",
@@ -124,7 +124,7 @@ func GetStateMachineObject1(format string) *client.StateMachineObject {
 	}
 }
 
-func GetStateMachineObject2(format string) *client.StateMachineObject {
+func GetStateMachineObject2(format string) *statemachine.StateMachineObject {
 	var retryMap map[string]interface{}
 
 	switch format {
@@ -148,7 +148,7 @@ func GetStateMachineObject2(format string) *client.StateMachineObject {
 		}
 	}
 
-	return &client.StateMachineObject{
+	return &statemachine.StateMachineObject{
 		Name:       "simpleTestStateMachine",
 		Comment:    "测试状态机定义",
 		StartState: "FirstState",
@@ -283,7 +283,7 @@ func GetStateMachineObject2(format string) *client.StateMachineObject {
 	}
 }
 
-func GetStateMachineObject3(format string) *client.StateMachineObject {
+func GetStateMachineObject3(format string) *statemachine.StateMachineObject {
 	var (
 		boundsMap1 map[string]interface{}
 		boundsMap2 map[string]interface{}
@@ -686,7 +686,7 @@ func GetStateMachineObject3(format string) *client.StateMachineObject {
 		}
 	}
 
-	return &client.StateMachineObject{
+	return &statemachine.StateMachineObject{
 		Name:                        "StateMachineNewDesigner",
 		Comment:                     "This state machine is modeled by designer tools.",
 		Version:                     "0.0.1",

--- a/pkg/saga/statemachine/statelang/parser/statemachine_config_parser_test.go
+++ b/pkg/saga/statemachine/statelang/parser/statemachine_config_parser_test.go
@@ -18,6 +18,7 @@
 package parser
 
 import (
+	"github.com/seata/seata-go/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -26,39 +27,39 @@ func TestStateMachineConfigParser_Parse(t *testing.T) {
 	parser := NewStateMachineConfigParser()
 
 	tests := []struct {
-		name                       string
-		configFilePath             string
-		expectedStateMachineObject *StateMachineObject
+		name           string
+		configFilePath string
+		expectedObject *client.StateMachineObject
 	}{
 		{
-			name:                       "JSON Simple 1",
-			configFilePath:             "../../../../../testdata/saga/statelang/simple_statelang_with_choice.json",
-			expectedStateMachineObject: GetStateMachineObject1("json"),
+			name:           "JSON Simple 1",
+			configFilePath: "../../../../../testdata/saga/statelang/simple_statelang_with_choice.json",
+			expectedObject: GetStateMachineObject1("json"),
 		},
 		{
-			name:                       "JSON Simple 2",
-			configFilePath:             "../../../../../testdata/saga/statelang/simple_statemachine.json",
-			expectedStateMachineObject: GetStateMachineObject2("json"),
+			name:           "JSON Simple 2",
+			configFilePath: "../../../../../testdata/saga/statelang/simple_statemachine.json",
+			expectedObject: GetStateMachineObject2("json"),
 		},
 		{
-			name:                       "JSON Simple 3",
-			configFilePath:             "../../../../../testdata/saga/statelang/state_machine_new_designer.json",
-			expectedStateMachineObject: GetStateMachineObject3("json"),
+			name:           "JSON Simple 3",
+			configFilePath: "../../../../../testdata/saga/statelang/state_machine_new_designer.json",
+			expectedObject: GetStateMachineObject3("json"),
 		},
 		{
-			name:                       "YAML Simple 1",
-			configFilePath:             "../../../../../testdata/saga/statelang/simple_statelang_with_choice.yaml",
-			expectedStateMachineObject: GetStateMachineObject1("yaml"),
+			name:           "YAML Simple 1",
+			configFilePath: "../../../../../testdata/saga/statelang/simple_statelang_with_choice.yaml",
+			expectedObject: GetStateMachineObject1("yaml"),
 		},
 		{
-			name:                       "YAML Simple 2",
-			configFilePath:             "../../../../../testdata/saga/statelang/simple_statemachine.yaml",
-			expectedStateMachineObject: GetStateMachineObject2("yaml"),
+			name:           "YAML Simple 2",
+			configFilePath: "../../../../../testdata/saga/statelang/simple_statemachine.yaml",
+			expectedObject: GetStateMachineObject2("yaml"),
 		},
 		{
-			name:                       "YAML Simple 3",
-			configFilePath:             "../../../../../testdata/saga/statelang/state_machine_new_designer.yaml",
-			expectedStateMachineObject: GetStateMachineObject3("yaml"),
+			name:           "YAML Simple 3",
+			configFilePath: "../../../../../testdata/saga/statelang/state_machine_new_designer.yaml",
+			expectedObject: GetStateMachineObject3("yaml"),
 		},
 	}
 
@@ -72,18 +73,18 @@ func TestStateMachineConfigParser_Parse(t *testing.T) {
 			if err != nil {
 				t.Error("parse fail: " + err.Error())
 			}
-			assert.Equal(t, tt.expectedStateMachineObject, object)
+			assert.Equal(t, tt.expectedObject, object)
 		})
 	}
 }
 
-func GetStateMachineObject1(format string) *StateMachineObject {
+func GetStateMachineObject1(format string) *client.StateMachineObject {
 	switch format {
 	case "json":
 	case "yaml":
 	}
 
-	return &StateMachineObject{
+	return &client.StateMachineObject{
 		Name:       "simpleChoiceTestStateMachine",
 		Comment:    "带条件分支的测试状态机定义",
 		StartState: "FirstState",
@@ -123,7 +124,7 @@ func GetStateMachineObject1(format string) *StateMachineObject {
 	}
 }
 
-func GetStateMachineObject2(format string) *StateMachineObject {
+func GetStateMachineObject2(format string) *client.StateMachineObject {
 	var retryMap map[string]interface{}
 
 	switch format {
@@ -147,7 +148,7 @@ func GetStateMachineObject2(format string) *StateMachineObject {
 		}
 	}
 
-	return &StateMachineObject{
+	return &client.StateMachineObject{
 		Name:       "simpleTestStateMachine",
 		Comment:    "测试状态机定义",
 		StartState: "FirstState",
@@ -282,7 +283,7 @@ func GetStateMachineObject2(format string) *StateMachineObject {
 	}
 }
 
-func GetStateMachineObject3(format string) *StateMachineObject {
+func GetStateMachineObject3(format string) *client.StateMachineObject {
 	var (
 		boundsMap1 map[string]interface{}
 		boundsMap2 map[string]interface{}
@@ -685,7 +686,7 @@ func GetStateMachineObject3(format string) *StateMachineObject {
 		}
 	}
 
-	return &StateMachineObject{
+	return &client.StateMachineObject{
 		Name:                        "StateMachineNewDesigner",
 		Comment:                     "This state machine is modeled by designer tools.",
 		Version:                     "0.0.1",

--- a/pkg/saga/statemachine/statelang/parser/statemachine_json_parser.go
+++ b/pkg/saga/statemachine/statelang/parser/statemachine_json_parser.go
@@ -106,14 +106,13 @@ func (stateMachineParser JSONStateMachineParser) Parse(content string) (statelan
 }
 
 func (stateMachineParser JSONStateMachineParser) setForCompensation(stateValue statelang.State, stateMachine *statelang.StateMachineImpl) {
-	switch stateValue.Type() {
-	case stateValue.Type():
+	if stateValue.Type() == constant.StateTypeServiceTask {
 		serviceTaskStateImpl, ok := stateValue.(*state.ServiceTaskStateImpl)
 		if ok {
 			if serviceTaskStateImpl.CompensateState() != "" {
 				compState := stateMachine.States()[serviceTaskStateImpl.CompensateState()]
 				if stateMachineParser.isTaskState(compState.Type()) {
-					compStateImpl, ok := compState.(state.ServiceTaskStateImpl)
+					compStateImpl, ok := compState.(*state.ServiceTaskStateImpl)
 					if ok {
 						compStateImpl.SetForCompensation(true)
 					}

--- a/pkg/saga/statemachine/statelang/parser/statemachine_json_parser_test.go
+++ b/pkg/saga/statemachine/statelang/parser/statemachine_json_parser_test.go
@@ -18,8 +18,17 @@
 package parser
 
 import (
+	"os"
 	"testing"
 )
+
+func readFileContent(filePath string) (string, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
 
 func TestParseChoice(t *testing.T) {
 	parser := NewJSONStateMachineParser()
@@ -40,7 +49,12 @@ func TestParseChoice(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parser.Parse(tt.configFilePath)
+			content, err := readFileContent(tt.configFilePath)
+			if err != nil {
+				t.Error("read file fail: " + err.Error())
+				return
+			}
+			_, err = parser.Parse(content)
 			if err != nil {
 				t.Error("parse fail: " + err.Error())
 			}
@@ -67,7 +81,12 @@ func TestParseServiceTaskForSimpleStateMachine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parser.Parse(tt.configFilePath)
+			content, err := readFileContent(tt.configFilePath)
+			if err != nil {
+				t.Error("read file fail: " + err.Error())
+				return
+			}
+			_, err = parser.Parse(content)
 			if err != nil {
 				t.Error("parse fail: " + err.Error())
 			}
@@ -94,7 +113,12 @@ func TestParseServiceTaskForNewDesigner(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := parser.Parse(tt.configFilePath)
+			content, err := readFileContent(tt.configFilePath)
+			if err != nil {
+				t.Error("read file fail: " + err.Error())
+				return
+			}
+			_, err = parser.Parse(content)
 			if err != nil {
 				t.Error("parse fail: " + err.Error())
 			}

--- a/pkg/saga/statemachine/statemachine.go
+++ b/pkg/saga/statemachine/statemachine.go
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package statemachine
+
+import (
+	"flag"
+)
+
+type StateMachineObject struct {
+	Name                        string                 `json:"Name" yaml:"Name"`
+	Comment                     string                 `json:"Comment" yaml:"Comment"`
+	Version                     string                 `json:"Version" yaml:"Version"`
+	StartState                  string                 `json:"StartState" yaml:"StartState"`
+	RecoverStrategy             string                 `json:"RecoverStrategy" yaml:"RecoverStrategy"`
+	Persist                     bool                   `json:"IsPersist" yaml:"IsPersist"`
+	RetryPersistModeUpdate      bool                   `json:"IsRetryPersistModeUpdate" yaml:"IsRetryPersistModeUpdate"`
+	CompensatePersistModeUpdate bool                   `json:"IsCompensatePersistModeUpdate" yaml:"IsCompensatePersistModeUpdate"`
+	Type                        string                 `json:"Type" yaml:"Type"`
+	States                      map[string]interface{} `json:"States" yaml:"States"`
+}
+
+func (smo *StateMachineObject) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&smo.Name, prefix+".name", "", "State machine name.")
+	f.StringVar(&smo.Comment, prefix+".comment", "", "State machine comment.")
+	f.StringVar(&smo.Version, prefix+".version", "1.0", "State machine version.")
+	f.StringVar(&smo.StartState, prefix+".start-state", "", "State machine start state.")
+	f.StringVar(&smo.RecoverStrategy, prefix+".recover-strategy", "", "State machine recovery strategy.")
+	f.BoolVar(&smo.Persist, prefix+".persist", false, "Whether to persist state machine.")
+	f.BoolVar(&smo.RetryPersistModeUpdate, prefix+".retry-persist-mode-update", false, "Whether to use update mode for retry persistence.")
+	f.BoolVar(&smo.CompensatePersistModeUpdate, prefix+".compensate-persist-mode-update", false, "Whether to use update mode for compensate persistence.")
+	f.StringVar(&smo.Type, prefix+".type", "", "State machine type.")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:  

This PR migrates StateMachineObject to client/config, adds SagaConfig to the main Config struct, and replaces direct JSON/YAML parsing with koanf for unified configuration handling. It updates field tags to align with koanf, refactors parsers for consistency, and updates tests to reflect configuration changes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #773 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
1. **StateMachineObject Field Tags**:  
   Field tags in `StateMachineObject` are renamed to lowercase (e.g., `"Name"` → `"name"`) to align with `koanf` parsing. Users must update their code or configuration files if manually constructing/serializing this struct.

2. **New SagaConfig Field**:  
   A `SagaConfig` field is added to the root `Config` struct. If users need to configure Saga-related settings, they must include this field in their JSON/YAML configuration files.

3. **Package Path Change**:  
   The `StateMachineObject` struct is moved from the `parser` package to `client/config`. Users importing this struct must update their import paths.

**Action Required**:  
- Update field tags in code/configs for `StateMachineObject`.  
- Add `SagaConfig` to configuration files if Saga features are used.  
- Adjust import paths for `StateMachineObject`.
```