### PR TITLE
refactor: implement pending TODOs in machine status_decision logic

### DIFF
--- a/pkg/saga/statemachine/constant/constant.go
+++ b/pkg/saga/statemachine/constant/constant.go
@@ -17,6 +17,8 @@
 
 package constant
 
+type NetExceptionType string
+
 const (
 	// region State Types
 	StateTypeServiceTask          string = "ServiceTask"
@@ -89,4 +91,11 @@ const (
 	// end region
 
 	SeperatorParentId string = ":"
+
+	// Machine execution timeout error code
+	FrameworkErrorCodeStateMachineExecutionTimeout                  = "StateMachineExecutionTimeout"
+	ConnectException                               NetExceptionType = "CONNECT_EXCEPTION"
+	ConnectTimeoutException                        NetExceptionType = "CONNECT_TIMEOUT_EXCEPTION"
+	ReadTimeoutException                           NetExceptionType = "READ_TIMEOUT_EXCEPTION"
+	NotNetException                                NetExceptionType = "NOT_NET_EXCEPTION"
 )

--- a/pkg/saga/statemachine/engine/core/engine_utils.go
+++ b/pkg/saga/statemachine/engine/core/engine_utils.go
@@ -164,3 +164,21 @@ func IsTimeout(gmtUpdated time.Time, timeoutMillis int) bool {
 func GenerateParentId(stateInstance statelang.StateInstance) string {
 	return stateInstance.MachineInstanceID() + constant.SeperatorParentId + stateInstance.ID()
 }
+
+// GetNetExceptionType Speculate what kind of network anomaly is caused by the error
+func GetNetExceptionType(err error) constant.NetExceptionType {
+	if err == nil {
+		return constant.NotNetException
+	}
+
+	// If it contains a specific error message, simply guess
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "connection refused") {
+		return constant.ConnectException
+	} else if strings.Contains(errMsg, "timeout") {
+		return constant.ConnectTimeoutException
+	} else if strings.Contains(errMsg, "i/o timeout") {
+		return constant.ReadTimeoutException
+	}
+	return constant.NotNetException
+}

--- a/pkg/saga/statemachine/engine/exception/exception.go
+++ b/pkg/saga/statemachine/engine/exception/exception.go
@@ -17,7 +17,10 @@
 
 package exception
 
-import "github.com/seata/seata-go/pkg/util/errors"
+import (
+	"fmt"
+	"github.com/seata/seata-go/pkg/util/errors"
+)
 
 type EngineExecutionException struct {
 	errors.SeataError
@@ -25,6 +28,11 @@ type EngineExecutionException struct {
 	stateMachineName       string
 	stateMachineInstanceId string
 	stateInstanceId        string
+	ErrCode                string
+}
+
+func (e *EngineExecutionException) Error() string {
+	return fmt.Sprintf("EngineExecutionException: %s", e.ErrCode)
 }
 
 func NewEngineExecutionException(code errors.TransactionErrorCode, msg string, parent error) *EngineExecutionException {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**: Issue#803 has been completed, and the TODO method in StatusDecisionStrategy has been completed

**Which issue(s) this PR fixes**:[Sage state machine judgment](https://github.com/apache/incubator-seata-go/issues/803)
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```