### PR TITLE
fix: remove hardcoded DBTypeMySQL in AT executors and improve multi-DB escape handling

### DIFF
--- a/pkg/datasource/sql/exec/at/at_executor.go
+++ b/pkg/datasource/sql/exec/at/at_executor.go
@@ -29,6 +29,8 @@ import (
 
 func Init() {
 	exec.RegisterATExecutor(types.DBTypeMySQL, func() exec.SQLExecutor { return &ATExecutor{} })
+	exec.RegisterATExecutor(types.DBTypeMARIADB, func() exec.SQLExecutor { return &ATExecutor{} })
+	exec.RegisterATExecutor(types.DBTypeOracle, func() exec.SQLExecutor { return &ATExecutor{} })
 }
 
 type executor interface {

--- a/pkg/datasource/sql/exec/at/at_executor_test.go
+++ b/pkg/datasource/sql/exec/at/at_executor_test.go
@@ -120,6 +120,7 @@ func TestATExecutor_ExecWithNamedValue_NonGlobalTx(t *testing.T) {
 
 			executor := &ATExecutor{}
 			execCtx := &types.ExecContext{
+				DBType:      types.DBTypeMySQL,
 				Query:       tt.query,
 				NamedValues: []driver.NamedValue{{Value: "test"}},
 			}
@@ -214,6 +215,7 @@ func TestATExecutor_ExecWithNamedValue_GlobalTx(t *testing.T) {
 				},
 			}
 			execCtx := &types.ExecContext{
+				DBType:      types.DBTypeMySQL,
 				Query:       tt.query,
 				NamedValues: []driver.NamedValue{{Value: "test"}},
 			}
@@ -244,6 +246,7 @@ func TestATExecutor_ExecWithNamedValue_ParserError(t *testing.T) {
 
 	executor := &ATExecutor{}
 	execCtx := &types.ExecContext{
+		DBType:      types.DBTypeMySQL,
 		Query:       "INVALID SQL",
 		NamedValues: []driver.NamedValue{},
 	}
@@ -310,6 +313,7 @@ func TestATExecutor_ExecWithValue(t *testing.T) {
 
 			executor := &ATExecutor{}
 			execCtx := &types.ExecContext{
+				DBType: types.DBTypeMySQL,
 				Query:  tt.query,
 				Values: tt.values,
 			}
@@ -344,6 +348,7 @@ func TestATExecutor_ExecWithValue_ParserError(t *testing.T) {
 
 	executor := &ATExecutor{}
 	execCtx := &types.ExecContext{
+		DBType: types.DBTypeMySQL,
 		Query:  "INVALID SQL",
 		Values: []driver.Value{"test"},
 	}

--- a/pkg/datasource/sql/exec/at/delete_executor.go
+++ b/pkg/datasource/sql/exec/at/delete_executor.go
@@ -103,7 +103,7 @@ func (d *deleteExecutor) beforeImage(ctx context.Context) (*types.RecordImage, e
 	}
 
 	tableName, _ := d.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, d.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(d.execContext.DBType).GetTableMeta(ctx, d.execContext.DBName, tableName)
 
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func (d *deleteExecutor) buildBeforeImageSQL(query string, args []driver.NamedVa
 // afterImage build after image
 func (d *deleteExecutor) afterImage(ctx context.Context) (*types.RecordImage, error) {
 	tableName, _ := d.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, d.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(d.execContext.DBType).GetTableMeta(ctx, d.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datasource/sql/exec/at/delete_executor_test.go
+++ b/pkg/datasource/sql/exec/at/delete_executor_test.go
@@ -72,7 +72,7 @@ func Test_deleteExecutor_buildBeforeImageSQL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := parser.DoParser(tt.sourceQuery)
 			assert.Nil(t, err)
-			executor := NewDeleteExecutor(c, &types.ExecContext{Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
+			executor := NewDeleteExecutor(c, &types.ExecContext{DBType: types.DBTypeMySQL, Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
 			query, args, err := executor.(*deleteExecutor).buildBeforeImageSQL(tt.sourceQuery, util.ValueToNamedValue(tt.sourceQueryArgs))
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expectQuery, query)

--- a/pkg/datasource/sql/exec/at/escape.go
+++ b/pkg/datasource/sql/exec/at/escape.go
@@ -34,7 +34,7 @@ const (
 // DelEscape del escape by db type
 func DelEscape(colName string, dbType types.DBType) string {
 	newColName := delEscape(colName, escapeStandard)
-	if dbType == types.DBTypeMySQL {
+	if dbType == types.DBTypeMySQL || dbType == types.DBTypeMARIADB {
 		newColName = delEscape(newColName, escapeMysql)
 	}
 	return newColName
@@ -76,7 +76,7 @@ func delEscape(colName string, escape string) string {
 
 // AddEscape if necessary, add escape by db type
 func AddEscape(colName string, dbType types.DBType) string {
-	if dbType == types.DBTypeMySQL {
+	if dbType == types.DBTypeMySQL || dbType == types.DBTypeMARIADB {
 		return addEscape(colName, dbType, escapeMysql)
 	}
 
@@ -152,13 +152,15 @@ func addEscape(colName string, dbType types.DBType, escape string) string {
 // checkEscape check whether given field or table name use keywords. the method has database special logic.
 func checkEscape(colName string, dbType types.DBType) bool {
 	switch dbType {
-	case types.DBTypeMySQL:
+	case types.DBTypeMySQL, types.DBTypeMARIADB:
 		if _, ok := types.GetMysqlKeyWord()[strings.ToUpper(colName)]; ok {
 			return true
 		}
-
 		return false
-	// TODO impl Oracle PG SQLServer ...
+	case types.DBTypeOracle:
+		// Oracle reserved words - for now, always escape to be safe
+		// TODO: implement Oracle keyword checker similar to mysql_keyword_checker.go
+		return true
 	default:
 		return true
 	}

--- a/pkg/datasource/sql/exec/at/escape_multidb_test.go
+++ b/pkg/datasource/sql/exec/at/escape_multidb_test.go
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package at
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"seata.apache.org/seata-go/v2/pkg/datasource/sql/types"
+)
+
+func TestDelEscapeMariaDB(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"backtick escape", "`id`", "id"},
+		{"no escape", "id", "id"},
+		{"backtick schema.column", "`scheme`.`id`", "scheme.id"},
+		{"double quote escape", `"id"`, "id"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DelEscape(tt.input, types.DBTypeMARIADB)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDelEscapeOracle(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"double quote escape", `"ID"`, "ID"},
+		{"no escape", "ID", "ID"},
+		{"double quote schema.column", `"SCHEMA"."ID"`, "SCHEMA.ID"},
+		// Oracle does NOT use backtick escaping
+		{"backtick preserved", "`ID`", "`ID`"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DelEscape(tt.input, types.DBTypeOracle)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAddEscapeMariaDB(t *testing.T) {
+	// MariaDB should use backtick escaping (same as MySQL)
+	result := AddEscape("select", types.DBTypeMARIADB)
+	assert.True(t, result[0] == '`' && result[len(result)-1] == '`', "MariaDB should use backtick escaping")
+}
+
+func TestAddEscapeOracle(t *testing.T) {
+	// Oracle should use double-quote escaping
+	result := AddEscape("ID", types.DBTypeOracle)
+	assert.True(t, result[0] == '"' && result[len(result)-1] == '"', "Oracle should use double-quote escaping")
+}
+
+func TestCheckEscapeMariaDB(t *testing.T) {
+	// MariaDB should use MySQL keyword checker
+	assert.True(t, checkEscape("SELECT", types.DBTypeMARIADB))
+	assert.True(t, checkEscape("TABLE", types.DBTypeMARIADB))
+}
+
+func TestCheckEscapeOracle(t *testing.T) {
+	// Oracle currently always escapes (safe default)
+	assert.True(t, checkEscape("ID", types.DBTypeOracle))
+	assert.True(t, checkEscape("USER_NAME", types.DBTypeOracle))
+}
+
+func TestBuildWhereConditionByPKs_MultiDB(t *testing.T) {
+	// Use SQL keywords so they get escaped
+	pks := []string{"select", "table"}
+
+	mysqlResult := BuildWhereConditionByPKs(pks, types.DBTypeMySQL)
+	mariaResult := BuildWhereConditionByPKs(pks, types.DBTypeMARIADB)
+
+	// MySQL and MariaDB should produce same result (both use backtick)
+	assert.Equal(t, mysqlResult, mariaResult)
+	assert.Contains(t, mysqlResult, "`select`")
+	assert.Contains(t, mysqlResult, " and ")
+
+	oracleResult := BuildWhereConditionByPKs(pks, types.DBTypeOracle)
+	// Oracle should use double-quote
+	assert.Contains(t, oracleResult, `"select"`)
+	assert.Contains(t, oracleResult, " and ")
+}

--- a/pkg/datasource/sql/exec/at/insert_executor.go
+++ b/pkg/datasource/sql/exec/at/insert_executor.go
@@ -84,7 +84,7 @@ func (i *insertExecutor) ExecContext(ctx context.Context, f exec.CallbackWithNam
 // beforeImage build before image
 func (i *insertExecutor) beforeImage(ctx context.Context) (*types.RecordImage, error) {
 	tableName, _ := i.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, i.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(i.execContext.DBType).GetTableMeta(ctx, i.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (i *insertExecutor) afterImage(ctx context.Context) (*types.RecordImage, er
 	}
 
 	tableName, _ := i.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, i.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(i.execContext.DBType).GetTableMeta(ctx, i.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (i *insertExecutor) buildAfterImageSQL(ctx context.Context) (string, []driv
 	// get all pk value
 	tableName, _ := i.parserCtx.GetTableName()
 
-	meta, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, i.execContext.DBName, tableName)
+	meta, err := datasource.GetTableCache(i.execContext.DBType).GetTableMeta(ctx, i.execContext.DBName, tableName)
 	if err != nil {
 		return "", nil, err
 	}
@@ -190,7 +190,7 @@ func (i *insertExecutor) buildAfterImageSQL(ctx context.Context) (string, []driv
 	for _, column := range i.parserCtx.InsertStmt.Columns {
 		insertColumns = append(insertColumns, column.Name.O)
 	}
-	sb.WriteString("SELECT " + strings.Join(i.getNeedColumns(meta, insertColumns, types.DBTypeMySQL), ", "))
+	sb.WriteString("SELECT " + strings.Join(i.getNeedColumns(meta, insertColumns, i.execContext.DBType), ", "))
 	suffix.WriteString(" FROM " + tableName)
 	whereSQL := i.buildWhereConditionByPKs(pkColumnNameList, rowSize, "mysql", maxInSize)
 	suffix.WriteString(" WHERE " + whereSQL + " ")
@@ -271,7 +271,7 @@ func (i *insertExecutor) containsPK(meta types.TableMeta, parseCtx *types.ParseC
 
 // containPK compare column name and primary key name
 func (i *insertExecutor) containPK(columnName string, meta types.TableMeta) bool {
-	newColumnName := DelEscape(columnName, types.DBTypeMySQL)
+	newColumnName := DelEscape(columnName, i.execContext.DBType)
 	pkColumnNameList := meta.GetPrimaryKeyOnlyName()
 	if len(pkColumnNameList) == 0 {
 		return false
@@ -314,7 +314,7 @@ func (i *insertExecutor) getPkIndex(InsertStmt *ast.InsertStmt, meta types.Table
 		tmpColumnMeta := columnMeta
 		pkIndex++
 		if i.containPK(tmpColumnMeta.ColumnName, meta) {
-			pkIndexMap[DelEscape(tmpColumnMeta.ColumnName, types.DBTypeMySQL)] = pkIndex
+			pkIndexMap[DelEscape(tmpColumnMeta.ColumnName, i.execContext.DBType)] = pkIndex
 		}
 	}
 
@@ -425,7 +425,7 @@ func (i *insertExecutor) getPkValuesByColumn(ctx context.Context, execCtx *types
 	}
 
 	tableName, _ := i.parserCtx.GetTableName()
-	meta, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, i.execContext.DBName, tableName)
+	meta, err := datasource.GetTableCache(i.execContext.DBType).GetTableMeta(ctx, i.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +464,7 @@ func (i *insertExecutor) getPkValuesByAuto(ctx context.Context, execCtx *types.E
 	}
 
 	tableName, _ := i.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, i.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(i.execContext.DBType).GetTableMeta(ctx, i.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datasource/sql/exec/at/insert_executor_test.go
+++ b/pkg/datasource/sql/exec/at/insert_executor_test.go
@@ -126,6 +126,7 @@ func TestBuildSelectSQLByInsert(t *testing.T) {
 			executor := NewInsertExecutor(c, &types.ExecContext{
 				Values:      test.queryArgs,
 				NamedValues: test.NamedValues,
+				DBType:      types.DBTypeMySQL,
 			}, []exec.SQLHook{})
 
 			executor.(*insertExecutor).businesSQLResult = &test.mockInsertResult
@@ -635,7 +636,7 @@ func TestMySQLInsertUndoLogBuilder_getPkValuesByColumn(t *testing.T) {
 					return &tt.args.meta, nil
 				})
 
-			executor := NewInsertExecutor(tt.args.execCtx.ParseContext, &types.ExecContext{}, []exec.SQLHook{})
+			executor := NewInsertExecutor(tt.args.execCtx.ParseContext, &types.ExecContext{DBType: types.DBTypeMySQL}, []exec.SQLHook{})
 			executor.(*insertExecutor).businesSQLResult = tt.fields.InsertResult
 			executor.(*insertExecutor).incrementStep = tt.fields.IncrementStep
 
@@ -736,7 +737,7 @@ func TestMySQLInsertUndoLogBuilder_getPkValuesByAuto(t *testing.T) {
 				func(_ *mysql.TableMetaCache, ctx context.Context, dbName, tableName string) (*types.TableMeta, error) {
 					return &tt.args.meta, nil
 				})
-			executor := NewInsertExecutor(nil, &types.ExecContext{}, []exec.SQLHook{})
+			executor := NewInsertExecutor(nil, &types.ExecContext{DBType: types.DBTypeMySQL}, []exec.SQLHook{})
 			executor.(*insertExecutor).businesSQLResult = tt.fields.InsertResult
 			executor.(*insertExecutor).incrementStep = tt.fields.IncrementStep
 			executor.(*insertExecutor).parserCtx = tt.args.execCtx.ParseContext

--- a/pkg/datasource/sql/exec/at/insert_on_update_executor.go
+++ b/pkg/datasource/sql/exec/at/insert_on_update_executor.go
@@ -97,7 +97,7 @@ func (i *insertOnUpdateExecutor) beforeImage(ctx context.Context) (*types.Record
 	if err != nil {
 		return nil, err
 	}
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, i.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(i.execContext.DBType).GetTableMeta(ctx, i.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -211,14 +211,15 @@ func (i *insertOnUpdateExecutor) buildBeforeImageSQLParameters(insertStmt *ast.I
 	parameterMap := make(map[string][]driver.NamedValue)
 	insertColumns := getInsertColumns(insertStmt)
 	placeHolderIndex := 0
+	dbType := i.execContext.DBType
 	for _, rowColumns := range insertRows {
 		if len(rowColumns) != len(insertColumns) {
 			log.Errorf("insert row's column size not equal to insert column size. row columns:%+v insert columns:%+v", rowColumns, insertColumns)
 			return nil, 0, fmt.Errorf("invalid insert row's column size")
 		}
-		for i, col := range insertColumns {
-			columnName := DelEscape(col, types.DBTypeMySQL)
-			val := rowColumns[i]
+		for idx, col := range insertColumns {
+			columnName := DelEscape(col, dbType)
+			val := rowColumns[idx]
 			rStr, ok := val.(string)
 			if ok && strings.EqualFold(rStr, sqlPlaceholder) {
 				objects := args[placeHolderIndex]
@@ -226,7 +227,7 @@ func (i *insertOnUpdateExecutor) buildBeforeImageSQLParameters(insertStmt *ast.I
 				placeHolderIndex++
 			} else {
 				parameterMap[columnName] = append(parameterMap[col], driver.NamedValue{
-					Ordinal: i + 1,
+					Ordinal: idx + 1,
 					Name:    columnName,
 					Value:   val,
 				})
@@ -264,7 +265,7 @@ func (i *insertOnUpdateExecutor) afterImage(ctx context.Context, beforeImages *t
 	if err != nil {
 		return nil, err
 	}
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, i.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(i.execContext.DBType).GetTableMeta(ctx, i.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +316,7 @@ func (i *insertOnUpdateExecutor) buildAfterImageSQL(beforeImage *types.RecordIma
 
 // isPKColumn check the column name to see if it is a primary key column
 func (i *insertOnUpdateExecutor) isPKColumn(columnName string, meta types.TableMeta) bool {
-	newColumnName := DelEscape(columnName, types.DBTypeMySQL)
+	newColumnName := DelEscape(columnName, i.execContext.DBType)
 	pkColumnNameList := meta.GetPrimaryKeyOnlyName()
 	if len(pkColumnNameList) == 0 {
 		return false

--- a/pkg/datasource/sql/exec/at/insert_on_update_executor_test.go
+++ b/pkg/datasource/sql/exec/at/insert_on_update_executor_test.go
@@ -31,6 +31,7 @@ import (
 func TestInsertOnUpdateBeforeImageSQL(t *testing.T) {
 	var (
 		ioe = insertOnUpdateExecutor{
+			execContext:               &types.ExecContext{DBType: types.DBTypeMySQL},
 			beforeImageSqlPrimaryKeys: make(map[string]bool),
 		}
 		tableMeta1 types.TableMeta

--- a/pkg/datasource/sql/exec/at/multi_delete_executor.go
+++ b/pkg/datasource/sql/exec/at/multi_delete_executor.go
@@ -111,7 +111,7 @@ func (m *multiDeleteExecutor) beforeImage(ctx context.Context) ([]*types.RecordI
 	if err != nil {
 		return nil, err
 	}
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, m.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(m.execContext.DBType).GetTableMeta(ctx, m.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (m *multiDeleteExecutor) beforeImage(ctx context.Context) ([]*types.RecordI
 
 func (m *multiDeleteExecutor) afterImage(ctx context.Context) ([]*types.RecordImage, error) {
 	tableName, _ := m.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, m.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(m.execContext.DBType).GetTableMeta(ctx, m.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datasource/sql/exec/at/multi_delete_executor_test.go
+++ b/pkg/datasource/sql/exec/at/multi_delete_executor_test.go
@@ -63,7 +63,7 @@ func Test_multiDeleteExecutor_buildBeforeImageSQL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			queryParser, err := parser.DoParser(tt.sourceQuery)
 			assert.Nil(t, err)
-			executor := NewMultiDeleteExecutor(queryParser, &types.ExecContext{Query: tt.sourceQuery, Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
+			executor := NewMultiDeleteExecutor(queryParser, &types.ExecContext{DBType: types.DBTypeMySQL, Query: tt.sourceQuery, Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
 			query, args, err := executor.buildBeforeImageSQL()
 			assert.Nil(t, err)
 			assert.Equal(t, query, tt.expectQuery)

--- a/pkg/datasource/sql/exec/at/multi_update_excutor.go
+++ b/pkg/datasource/sql/exec/at/multi_update_excutor.go
@@ -103,7 +103,7 @@ func (u *multiUpdateExecutor) beforeImage(ctx context.Context) ([]*types.RecordI
 	}
 
 	tableName := u.parserCtx.MultiStmt[0].UpdateStmt.TableRefs.TableRefs.Left.(*ast.TableSource).Source.(*ast.TableName).Name.O
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, u.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, u.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (u *multiUpdateExecutor) afterImage(ctx context.Context, beforeImages []*ty
 	beforeImage := beforeImages[0]
 
 	tableName := u.parserCtx.MultiStmt[0].UpdateStmt.TableRefs.TableRefs.Left.(*ast.TableSource).Source.(*ast.TableName).Name.O
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, u.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, u.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datasource/sql/exec/at/multi_update_excutor_test.go
+++ b/pkg/datasource/sql/exec/at/multi_update_excutor_test.go
@@ -74,7 +74,7 @@ func TestBuildSelectSQLByMultiUpdate(t *testing.T) {
 			//for _, v := range c.MultiStmt {
 			//	updateStmts = append(updateStmts, v.UpdateStmt)
 			//}
-			executor := NewMultiUpdateExecutor(c, &types.ExecContext{NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
+			executor := NewMultiUpdateExecutor(c, &types.ExecContext{DBType: types.DBTypeMySQL, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
 
 			query, args, err := executor.buildBeforeImageSQL(util.ValueToNamedValue(tt.sourceQueryArgs), &types.TableMeta{})
 			assert.NoError(t, err)
@@ -93,7 +93,7 @@ func TestBuildSelectSQLByMultiUpdate(t *testing.T) {
 	//	updateStmts = append(updateStmts, v.UpdateStmt)
 	//}
 
-	executor := NewMultiUpdateExecutor(c, &types.ExecContext{NamedValues: util.ValueToNamedValue(sourceQueryArgs)}, []exec.SQLHook{})
+	executor := NewMultiUpdateExecutor(c, &types.ExecContext{DBType: types.DBTypeMySQL, NamedValues: util.ValueToNamedValue(sourceQueryArgs)}, []exec.SQLHook{})
 	_, _, err = executor.buildBeforeImageSQL(util.ValueToNamedValue(sourceQueryArgs), &types.TableMeta{})
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "multi update SQL with orderBy condition is not support yet")
@@ -146,7 +146,7 @@ func TestBuildSelectSQLByMultiUpdateAllColumns(t *testing.T) {
 			//for _, v := range c.MultiStmt {
 			//	updateStmts = append(updateStmts, v.UpdateStmt)
 			//}
-			executor := NewMultiUpdateExecutor(c, &types.ExecContext{NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
+			executor := NewMultiUpdateExecutor(c, &types.ExecContext{DBType: types.DBTypeMySQL, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
 
 			query, args, err := executor.buildBeforeImageSQL(util.ValueToNamedValue(tt.sourceQueryArgs), &meta)
 			assert.NoError(t, err)
@@ -161,7 +161,7 @@ func TestBuildSelectSQLByMultiUpdateAllColumns(t *testing.T) {
 	c, err := parser.DoParser(sourceQuery)
 	assert.NoError(t, err)
 
-	executor := NewMultiUpdateExecutor(c, &types.ExecContext{NamedValues: util.ValueToNamedValue(sourceQueryArgs)}, []exec.SQLHook{})
+	executor := NewMultiUpdateExecutor(c, &types.ExecContext{DBType: types.DBTypeMySQL, NamedValues: util.ValueToNamedValue(sourceQueryArgs)}, []exec.SQLHook{})
 	_, _, err = executor.buildBeforeImageSQL(util.ValueToNamedValue(sourceQueryArgs), &meta)
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "multi update SQL with orderBy condition is not support yet")

--- a/pkg/datasource/sql/exec/at/select_for_update_executor.go
+++ b/pkg/datasource/sql/exec/at/select_for_update_executor.go
@@ -93,7 +93,7 @@ func (s *selectForUpdateExecutor) ExecContext(ctx context.Context, f exec.Callba
 		return nil, err
 	}
 
-	if s.metaData, err = datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, s.execContext.DBName, s.tableName); err != nil {
+	if s.metaData, err = datasource.GetTableCache(s.execContext.DBType).GetTableMeta(ctx, s.execContext.DBName, s.tableName); err != nil {
 		return nil, err
 	}
 

--- a/pkg/datasource/sql/exec/at/update_executor.go
+++ b/pkg/datasource/sql/exec/at/update_executor.go
@@ -102,7 +102,7 @@ func (u *updateExecutor) beforeImage(ctx context.Context) (*types.RecordImage, e
 	}
 
 	tableName, _ := u.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, u.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, u.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (u *updateExecutor) afterImage(ctx context.Context, beforeImage types.Recor
 	}
 
 	tableName, _ := u.parserCtx.GetTableName()
-	metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, u.execContext.DBName, tableName)
+	metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, u.execContext.DBName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (u *updateExecutor) buildBeforeImageSQL(ctx context.Context, args []driver.
 
 		// select indexes columns
 		tableName, _ := u.parserCtx.GetTableName()
-		metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, u.execContext.DBName, tableName)
+		metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, u.execContext.DBName, tableName)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/datasource/sql/exec/at/update_executor_test.go
+++ b/pkg/datasource/sql/exec/at/update_executor_test.go
@@ -90,7 +90,7 @@ func TestBuildSelectSQLByUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := parser.DoParser(tt.sourceQuery)
 			assert.Nil(t, err)
-			executor := NewUpdateExecutor(c, &types.ExecContext{Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
+			executor := NewUpdateExecutor(c, &types.ExecContext{DBType: types.DBTypeMySQL, Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
 			query, args, err := executor.(*updateExecutor).buildBeforeImageSQL(context.Background(), util.ValueToNamedValue(tt.sourceQueryArgs))
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expectQuery, query)

--- a/pkg/datasource/sql/exec/at/update_join_executor.go
+++ b/pkg/datasource/sql/exec/at/update_join_executor.go
@@ -112,7 +112,7 @@ func (u *updateJoinExecutor) beforeImage(ctx context.Context) ([]*types.RecordIm
 	var recordImages []*types.RecordImage
 
 	for tbName, tableAliases := range u.tableAliasesMap {
-		metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, u.execContext.DBName, tbName)
+		metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, u.execContext.DBName, tbName)
 		if err != nil {
 			return nil, err
 		}
@@ -162,7 +162,7 @@ func (u *updateJoinExecutor) afterImage(ctx context.Context, beforeImages []*typ
 
 	var recordImages []*types.RecordImage
 	for _, beforeImage := range beforeImages {
-		metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, u.execContext.DBName, beforeImage.TableName)
+		metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, u.execContext.DBName, beforeImage.TableName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/datasource/sql/exec/at/update_join_executor_test.go
+++ b/pkg/datasource/sql/exec/at/update_join_executor_test.go
@@ -216,7 +216,7 @@ func TestBuildSelectSQLByUpdateJoin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := parser.DoParser(tt.sourceQuery)
 			assert.Nil(t, err)
-			executor := NewUpdateJoinExecutor(c, &types.ExecContext{Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
+			executor := NewUpdateJoinExecutor(c, &types.ExecContext{DBType: types.DBTypeMySQL, Values: tt.sourceQueryArgs, NamedValues: util.ValueToNamedValue(tt.sourceQueryArgs)}, []exec.SQLHook{})
 			tableNames := executor.(*updateJoinExecutor).parseTableName(c.UpdateStmt.TableRefs.TableRefs)
 			for tbName, tableAliases := range tableNames {
 				query, args, err := executor.(*updateJoinExecutor).buildBeforeImageSQL(context.Background(), MetaDataMap[tbName], tableAliases, util.ValueToNamedValue(tt.sourceQueryArgs))


### PR DESCRIPTION
#### What this PR does

Removes all hardcoded `types.DBTypeMySQL` references across the AT executor layer, replacing them with `execContext.DBType` to enable multi-database AT mode support. Also extends escape handling to support MariaDB (backtick, same as MySQL) and Oracle (double-quote standard SQL) escaping.

#### Why

Every AT executor was hardcoded to look up only the MySQL table metadata cache:

```go
// BEFORE — always MySQL, panic for other DBs
metaData, err := datasource.GetTableCache(types.DBTypeMySQL).GetTableMeta(ctx, ...)

// AFTER — uses the actual database type from execution context
metaData, err := datasource.GetTableCache(u.execContext.DBType).GetTableMeta(ctx, ...)
```

#### Changes Summary

**Source files — replace `types.DBTypeMySQL` with `execContext.DBType` (11 files):**

| File                            | Changes                                                                               |
| ------------------------------- | ------------------------------------------------------------------------------------- |
| `escape.go`                     | `DelEscape`/`AddEscape`/`checkEscape` → handle MariaDB backtick + Oracle double-quote |
| `at_executor.go`                | Register AT executor for MariaDB + Oracle                                             |
| `insert_executor.go`            | 7 instances (`GetTableCache` + `DelEscape` + `getNeedColumns`)                        |
| `update_executor.go`            | 3 instances (`GetTableCache`)                                                         |
| `delete_executor.go`            | 2 instances (`GetTableCache`)                                                         |
| `multi_update_excutor.go`       | 2 instances (`GetTableCache`)                                                         |
| `multi_delete_executor.go`      | 2 instances (`GetTableCache`)                                                         |
| `insert_on_update_executor.go`  | 4 instances + **variable shadowing fix** (loop var `i` → `idx`)                       |
| `select_for_update_executor.go` | 1 instance (`GetTableCache`)                                                          |
| `update_executor.go`            | 3 instances (`GetTableCache`)                                                         |
| `update_join_executor.go`       | 2 instances (`GetTableCache`)                                                         |

**Test files — add `DBType: types.DBTypeMySQL` to test `ExecContext` (8 files):**

| File                                | Changes                                                                                                                                                                                                    |
| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `escape_multidb_test.go`            | **[NEW]** 7 tests: `TestDelEscapeMariaDB`, `TestDelEscapeOracle`, `TestAddEscapeMariaDB`, `TestAddEscapeOracle`, `TestCheckEscapeMariaDB`, `TestCheckEscapeOracle`, `TestBuildWhereConditionByPKs_MultiDB` |
| `at_executor_test.go`               | Add `DBType: types.DBTypeMySQL` (5 locations)                                                                                                                                                              |
| `insert_executor_test.go`           | Add `DBType: types.DBTypeMySQL` (3 locations)                                                                                                                                                              |
| `insert_on_update_executor_test.go` | Add `execContext` with `DBType: types.DBTypeMySQL` (1 location)                                                                                                                                            |
| `update_executor_test.go`           | Add `DBType: types.DBTypeMySQL` (1 location)                                                                                                                                                               |
| `multi_update_excutor_test.go`      | Add `DBType: types.DBTypeMySQL` (4 locations)                                                                                                                                                              |
| `delete_executor_test.go`           | Add `DBType: types.DBTypeMySQL` (1 location)                                                                                                                                                               |
| `update_join_executor_test.go`      | Add `DBType: types.DBTypeMySQL` (1 location)                                                                                                                                                               |

**Total: 19 files (11 source + 1 new test + 7 modified tests)**

#### Escape handling improvements

- `DelEscape`: MariaDB uses backtick escaping (same as MySQL); Oracle only uses double-quote
- `AddEscape`: MariaDB → backtick; Oracle → double-quote (standard SQL)
- `checkEscape`: MariaDB shares MySQL keyword list; Oracle escapes all identifiers (safe default)

#### Bug fix

- `insert_on_update_executor.go` line 219: Loop variable `i` (int) shadowed receiver `i *insertOnUpdateExecutor`. Fixed by renaming loop var to `idx` and capturing `dbType` before the loop.

#### Testing

```
✅ gofmt -s       — Clean (all 19 files)
✅ go vet          — Clean
✅ go build        — Clean
✅ All new escape tests (7) — PASS
✅ All existing executor tests — PASS
✅ License headers  — ASF 2.0 present on new file
✅ No cross-imports to PR#2/PR#3 packages
```

> **Note:** `TestATExecutor_ExecWithValue_ParserError` is a pre-existing flaky test caused by `gomonkey` stub race conditions between test functions. It fails on the **original unmodified code** as well (verified by running `git stash` + test on original). It passes when run in isolation. Not related to this PR.

#### Verification (pre-existing flaky test proof)

```bash
# Passes in isolation:
$ go test -run "TestATExecutor_ExecWithValue_ParserError$" ./pkg/datasource/sql/exec/at/...
ok  seata.apache.org/seata-go/v2/pkg/datasource/sql/exec/at  0.423s

# Fails on ORIGINAL unmodified code too:
$ git stash && go test ./pkg/datasource/sql/exec/at/...
FAIL  seata.apache.org/seata-go/v2/pkg/datasource/sql/exec/at  0.634s
```

issue https://github.com/apache/incubator-seata-go/issues/1055