### PR TITLE
ci: add workflow to block WIP pull requests

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -34,16 +34,22 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - name: "fail for wip pull request"
-        if: ${{ startsWith(github.event.pull_request.title, 'WIP') || contains(github.event.pull_request.labels.*.name, 'do-not-merge/wip') }}
+      - name: "check wip pull request"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
-          echo "This pull request is marked as WIP and cannot be merged."
-          echo "Remove the do-not-merge/wip label or update the title."
-          exit 1
+          if echo "$PR_TITLE" | grep -iqE '^[[:space:]]*(\[WIP\]|WIP\b)'; then
+            echo "::error::Pull request title starts with WIP. Please remove the WIP prefix to allow merging."
+            exit 1
+          fi
 
-      - name: "pass when pull request is mergeable"
-        if: ${{ !startsWith(github.event.pull_request.title, 'WIP') && !contains(github.event.pull_request.labels.*.name, 'do-not-merge/wip') }}
-        run: echo "Pull request passed WIP guard."
+          if echo ",$PR_LABELS," | grep -qi ',do-not-merge/wip,'; then
+            echo "::error::Pull request has the 'do-not-merge/wip' label. Please remove this label to allow merging."
+            exit 1
+          fi
+
+          echo "Pull request passed WIP guard."
 
   triage:
     permissions:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,9 +19,32 @@
 
 name: "pull request labeler"
 on:
-  - pull_request_target
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
 
 jobs:
+  block-wip:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: "fail for wip pull request"
+        if: ${{ startsWith(github.event.pull_request.title, 'WIP') || contains(github.event.pull_request.labels.*.name, 'do-not-merge/wip') }}
+        run: |
+          echo "This pull request is marked as WIP and cannot be merged."
+          echo "Remove the do-not-merge/wip label or update the title."
+          exit 1
+
+      - name: "pass when pull request is mergeable"
+        if: ${{ !startsWith(github.event.pull_request.title, 'WIP') && !contains(github.event.pull_request.labels.*.name, 'do-not-merge/wip') }}
+        run: echo "Pull request passed WIP guard."
+
   triage:
     permissions:
       contents: read


### PR DESCRIPTION
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata-go/tree/master/changes).

**What this PR does**:
This PR adds a `block-wip` job to the existing `labeler.yml` workflow to prevent accidental merges of incomplete PRs. 

Specifically, the workflow will fail and block the merge process if:
1. The PR title starts with `[WIP]` or `WIP`.
2. The PR contains the `do-not-merge/wip` label.

I also updated the `pull_request_target` trigger types to include `labeled` and `unlabeled`. This ensures the CI check status can be refreshed immediately when a maintainer manually adds or removes the wip label.

**Which issue(s) this PR fixes**:
Fixes #1053

**Special notes for your reviewer**:
Kindly review this PR at your convenience. I integrated the logic into the existing `labeler.yml` to smoothly reuse the `pull_request_target` context safely. 
Please let me know if any adjustment is needed.

**Does this PR introduce a user-facing change?**:
```release-note```
NONE