### PR TITLE
bugfix: fail fast for unimplemented registry types in InitRegistry

### DIFF
--- a/changes/dev.md
+++ b/changes/dev.md
@@ -31,6 +31,7 @@
 
   - [[#130](https://github.com/apache/incubator-seata-go/pull/130)] getty session auto close bug
   - [[#991](https://github.com/apache/incubator-seata-go/issues/991)] fix connection leaks and prevent nil pointer panic in async worker
+  - [[#1076](https://github.com/apache/incubator-seata-go/issues/1076)] Fail fast for unimplemented registry types in InitRegistry
 
 ### optimize：
 

--- a/pkg/discovery/init.go
+++ b/pkg/discovery/init.go
@@ -35,18 +35,8 @@ func InitRegistry(serviceConfig *ServiceConfig, registryConfig *RegistryConfig) 
 	case ETCD:
 		//init etcd registry
 		registryService = newEtcdRegistryService(serviceConfig, &registryConfig.Etcd3)
-	case NACOS:
-		//TODO: init nacos registry
-	case EUREKA:
-		//TODO: init eureka registry
-	case REDIS:
-		//TODO: init redis registry
-	case ZK:
-		//TODO: init zk registry
-	case CONSUL:
-		//TODO: init consul registry
-	case SOFA:
-		//TODO: init sofa registry
+	case NACOS, EUREKA, REDIS, ZK, CONSUL, SOFA:
+		err = fmt.Errorf("service registry type %s is not implemented", registryConfig.Type)
 	default:
 		err = fmt.Errorf("service registry not support registry type:%s", registryConfig.Type)
 	}

--- a/pkg/discovery/init_test.go
+++ b/pkg/discovery/init_test.go
@@ -18,7 +18,9 @@
 package discovery
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -28,10 +30,11 @@ func TestInitRegistry(t *testing.T) {
 		registryConfig *RegistryConfig
 	}
 	tests := []struct {
-		name         string
-		args         args
-		hasPanic     bool
-		expectedType string
+		name                 string
+		args                 args
+		hasPanic             bool
+		expectedType         string
+		panicMessageContains string
 	}{
 		{
 			name: "file",
@@ -72,13 +75,84 @@ func TestInitRegistry(t *testing.T) {
 			},
 			hasPanic: true,
 		},
+		{
+			name: "nacos type is not implemented",
+			args: args{
+				registryConfig: &RegistryConfig{
+					Type: NACOS,
+				},
+				serviceConfig: &ServiceConfig{},
+			},
+			hasPanic:             true,
+			panicMessageContains: fmt.Sprintf("service registry type %s is not implemented", NACOS),
+		},
+		{
+			name: "eureka type is not implemented",
+			args: args{
+				registryConfig: &RegistryConfig{
+					Type: EUREKA,
+				},
+				serviceConfig: &ServiceConfig{},
+			},
+			hasPanic:             true,
+			panicMessageContains: fmt.Sprintf("service registry type %s is not implemented", EUREKA),
+		},
+		{
+			name: "redis type is not implemented",
+			args: args{
+				registryConfig: &RegistryConfig{
+					Type: REDIS,
+				},
+				serviceConfig: &ServiceConfig{},
+			},
+			hasPanic:             true,
+			panicMessageContains: fmt.Sprintf("service registry type %s is not implemented", REDIS),
+		},
+		{
+			name: "zk type is not implemented",
+			args: args{
+				registryConfig: &RegistryConfig{
+					Type: ZK,
+				},
+				serviceConfig: &ServiceConfig{},
+			},
+			hasPanic:             true,
+			panicMessageContains: fmt.Sprintf("service registry type %s is not implemented", ZK),
+		},
+		{
+			name: "consul type is not implemented",
+			args: args{
+				registryConfig: &RegistryConfig{
+					Type: CONSUL,
+				},
+				serviceConfig: &ServiceConfig{},
+			},
+			hasPanic:             true,
+			panicMessageContains: fmt.Sprintf("service registry type %s is not implemented", CONSUL),
+		},
+		{
+			name: "sofa type is not implemented",
+			args: args{
+				registryConfig: &RegistryConfig{
+					Type: SOFA,
+				},
+				serviceConfig: &ServiceConfig{},
+			},
+			hasPanic:             true,
+			panicMessageContains: fmt.Sprintf("service registry type %s is not implemented", SOFA),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			registryServiceInstance = nil
 			defer func() {
 				if r := recover(); r != nil {
 					if !tt.hasPanic {
 						t.Errorf("panic is not expected!")
+						return
+					}
+					if tt.panicMessageContains != "" && !strings.Contains(fmt.Sprint(r), tt.panicMessageContains) {
+						t.Errorf("panic = %v, want message containing %q", r, tt.panicMessageContains)
 					}
 				} else if tt.hasPanic {
 					t.Errorf("Expected a panic but did not receive one")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata-go/tree/master/changes).

**What this PR does**:

Make `pkg/discovery.InitRegistry(...)` fail fast for currently recognized but unimplemented registry types (`nacos`, `eureka`, `redis`, `zk`, `consul`, and `sofa`) and add test coverage for those cases

**Which issue(s) this PR fixes**:

Fixes a discovery initialization bug where unimplemented registry types are accepted by name without returning a clear error

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #1076 

**Special notes for your reviewer**:

This PR is intentionally small and focused on the registry initialization path only. It does not implement new registry adapters and it makes the current support boundary explicit and adds tests for the fail-fast behavior

**Does this PR introduce a user-facing change?**:

Yes. Configuring an unimplemented registry type now fails fast with a clear error instead of being accepted silently during registry initialization

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Make `InitRegistry` fail fast for currently unimplemented registry types and add tests covering those cases
```