### PR TITLE
fix: align TCC resource manager fallback behavior

### DIFF
--- a/pkg/rm/tcc/tcc_resource.go
+++ b/pkg/rm/tcc/tcc_resource.go
@@ -104,14 +104,12 @@ func (t *TCCResourceManager) BranchReport(ctx context.Context, param rm.BranchRe
 }
 
 // LockQuery query lock status of transaction branch
-func (t *TCCResourceManager) LockQuery(ctx context.Context, param rm.LockQueryParam) (bool, error) {
-	// TODO implement me
-	panic("implement me")
+func (t *TCCResourceManager) LockQuery(_ context.Context, _ rm.LockQueryParam) (bool, error) {
+	return false, nil
 }
 
-func (t *TCCResourceManager) UnregisterResource(resource rm.Resource) error {
-	// TODO implement me
-	panic("implement me")
+func (t *TCCResourceManager) UnregisterResource(_ rm.Resource) error {
+	return fmt.Errorf("UnregisterResource is not supported for TCCResourceManager")
 }
 
 func (t *TCCResourceManager) RegisterResource(resource rm.Resource) error {

--- a/pkg/rm/tcc/tcc_resource_test.go
+++ b/pkg/rm/tcc/tcc_resource_test.go
@@ -33,6 +33,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type mockTCCManagedResource struct{}
+
+func (m mockTCCManagedResource) GetResourceGroupId() string {
+	return "DEFAULT"
+}
+
+func (m mockTCCManagedResource) GetResourceId() string {
+	return "mock-tcc-resource"
+}
+
+func (m mockTCCManagedResource) GetBranchType() branch.BranchType {
+	return branch.BranchTypeTCC
+}
+
 func TestActionContext(t *testing.T) {
 	applicationData := `{"actionContext":{"zhangsan":"lisi"}}`
 	businessActionContext := GetTCCResourceManagerInstance().
@@ -68,4 +82,22 @@ func TestBranchReport(t *testing.T) {
 		})
 
 	assert.Nil(t, err)
+}
+
+func TestLockQueryReturnsFalse(t *testing.T) {
+	lockable, err := GetTCCResourceManagerInstance().LockQuery(context.Background(), rm.LockQueryParam{
+		BranchType: branch.BranchTypeTCC,
+		ResourceId: "mock-tcc-resource",
+		Xid:        "xid-1",
+		LockKeys:   "ignored",
+	})
+
+	assert.NoError(t, err)
+	assert.False(t, lockable)
+}
+
+func TestUnregisterResourceReturnsExplicitError(t *testing.T) {
+	err := GetTCCResourceManagerInstance().UnregisterResource(mockTCCManagedResource{})
+
+	assert.EqualError(t, err, "UnregisterResource is not supported for TCCResourceManager")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata-go/tree/master/changes).

**What this PR does**:

As discussed in the recent community bi-weekly meeting, the missing implementations in `TCCResourceManager` cause panics when invoked, which is dangerous for the framework's stability.

 Thanks to @CAICAIIs for raising this issue and providing the excellent Java-side research! 

- replace `panic("implement me")` in `TCCResourceManager.LockQuery` with an explicit fallback return: `false, nil`
- replace `panic("implement me")` in `TCCResourceManager.UnregisterResource` with an explicit unsupported error
- add regression tests to verify both fallback paths no longer panic

**Which issue(s) this PR fixes**:

Fixes #1072

**Special notes for your reviewer**:

Seata Java `2.x` does not provide a TCC-specific implementation for these two methods either.

`TCCResourceManager` inherits the default fallback behavior from `AbstractResourceManager`:
- `lockQuery(...)` returns `false`
- `unregisterResource(...)` throws `NotSupportYetException`

This PR keeps the change small and makes the current fallback behavior explicit on the Go side, while leaving future TCC lifecycle changes to a separate discussion.
