### PR TITLE
fix: intercept REPLACE INTO statement in AT mode (#1121)

### DIFF
--- a/pkg/datasource/sql/exec/at/at_executor.go
+++ b/pkg/datasource/sql/exec/at/at_executor.go
@@ -20,6 +20,7 @@ package at
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/exec"
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/parser"
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/types"
@@ -68,6 +69,9 @@ func (e *ATExecutor) ExecWithNamedValue(ctx context.Context, execCtx *types.Exec
 	if !isGlobalTx(ctx) {
 		executor = newPlainExecutor(queryParser, execCtx)
 	} else {
+		if queryParser.ExecutorType == types.ReplaceIntoExecutor {
+			return nil, errors.New("NotSupportYetException: AT mode currently does not support REPLACE INTO statement")
+		}
 		switch queryParser.SQLType {
 		case types.SQLTypeInsert:
 			executor = newInsertExecutor(queryParser, execCtx, e.hooks)

--- a/pkg/datasource/sql/exec/at/at_executor_test.go
+++ b/pkg/datasource/sql/exec/at/at_executor_test.go
@@ -490,6 +490,129 @@ func TestATExecutors_ExecContext_BeforeHookError(t *testing.T) {
 	}
 }
 
+func TestATExecutor_ExecWithNamedValue_ReplaceInto_GlobalTx(t *testing.T) {
+	originalIsGlobalTx := isGlobalTx
+	originalParseSQLQuery := parseSQLQuery
+	t.Cleanup(func() {
+		isGlobalTx = originalIsGlobalTx
+		parseSQLQuery = originalParseSQLQuery
+	})
+
+	isGlobalTx = func(ctx context.Context) bool {
+		return true
+	}
+	parseSQLQuery = func(query string) (*types.ParseContext, error) {
+		return &types.ParseContext{
+			SQLType:      types.SQLTypeInsert,
+			ExecutorType: types.ReplaceIntoExecutor,
+		}, nil
+	}
+
+	executor := &ATExecutor{}
+	execCtx := &types.ExecContext{
+		Query:       "REPLACE INTO users (id, name) VALUES (?, ?)",
+		NamedValues: []driver.NamedValue{{Name: "", Value: 1}, {Name: "", Value: "new"}},
+	}
+
+	callCount := 0
+	callback := func(ctx context.Context, query string, args []driver.NamedValue) (types.ExecResult, error) {
+		callCount++
+		return &mockExecResult{rowsAffected: 1}, nil
+	}
+
+	result, err := executor.ExecWithNamedValue(context.Background(), execCtx, callback)
+
+	assert.Error(t, err, "should return error")
+	if err != nil {
+		assert.Contains(t, err.Error(), "NotSupportYetException: AT mode currently does not support REPLACE INTO statement")
+	}
+	assert.Nil(t, result, "result should be nil on error")
+	assert.Equal(t, 0, callCount, "callback should not be called because of early interception")
+}
+
+func TestATExecutor_ExecWithValue_ReplaceInto_GlobalTx(t *testing.T) {
+	originalIsGlobalTx := isGlobalTx
+	originalParseSQLQuery := parseSQLQuery
+	t.Cleanup(func() {
+		isGlobalTx = originalIsGlobalTx
+		parseSQLQuery = originalParseSQLQuery
+	})
+
+	isGlobalTx = func(ctx context.Context) bool {
+		return true
+	}
+	parseSQLQuery = func(query string) (*types.ParseContext, error) {
+		return &types.ParseContext{
+			SQLType:      types.SQLTypeInsert,
+			ExecutorType: types.ReplaceIntoExecutor,
+		}, nil
+	}
+
+	executor := &ATExecutor{}
+	execCtx := &types.ExecContext{
+		Query:  "REPLACE INTO users (id, name) VALUES (?, ?)",
+		Values: []driver.Value{1, "new"},
+	}
+
+	callCount := 0
+	callback := func(ctx context.Context, query string, args []driver.NamedValue) (types.ExecResult, error) {
+		callCount++
+		return &mockExecResult{rowsAffected: 1}, nil
+	}
+
+	result, err := executor.ExecWithValue(context.Background(), execCtx, callback)
+
+	assert.Error(t, err, "should return error")
+	if err != nil {
+		assert.Contains(t, err.Error(), "NotSupportYetException: AT mode currently does not support REPLACE INTO statement")
+	}
+	assert.Nil(t, result, "result should be nil on error")
+	assert.Equal(t, 0, callCount, "callback should not be called because of early interception")
+}
+
+func TestATExecutor_ExecWithNamedValue_ReplaceInto_NonGlobalTx(t *testing.T) {
+	originalIsGlobalTx := isGlobalTx
+	originalParseSQLQuery := parseSQLQuery
+	t.Cleanup(func() {
+		isGlobalTx = originalIsGlobalTx
+		parseSQLQuery = originalParseSQLQuery
+	})
+
+	isGlobalTx = func(ctx context.Context) bool {
+		return false
+	}
+	parseSQLQuery = func(query string) (*types.ParseContext, error) {
+		return &types.ParseContext{
+			SQLType:      types.SQLTypeInsert,
+			ExecutorType: types.ReplaceIntoExecutor,
+		}, nil
+	}
+
+	replaceATExecutorFactories(t, &mockExecutor{
+		execContextFunc: func(ctx context.Context, f exec.CallbackWithNamedValue) (types.ExecResult, error) {
+			return f(ctx, "", nil)
+		},
+	})
+
+	executor := &ATExecutor{}
+	execCtx := &types.ExecContext{
+		Query:       "REPLACE INTO users (id, name) VALUES (?, ?)",
+		NamedValues: []driver.NamedValue{{Name: "", Value: 1}, {Name: "", Value: "new"}},
+	}
+
+	callCount := 0
+	callback := func(ctx context.Context, query string, args []driver.NamedValue) (types.ExecResult, error) {
+		callCount++
+		return &mockExecResult{rowsAffected: 1}, nil
+	}
+
+	result, err := executor.ExecWithNamedValue(context.Background(), execCtx, callback)
+
+	assert.NoError(t, err, "should not return error in non-global tx")
+	assert.NotNil(t, result, "result should not be nil")
+	assert.Equal(t, 1, callCount, "callback should be called exactly once (passed through)")
+}
+
 type mockSQLHook struct {
 	sqlType         types.SQLType
 	beforeCallCount int


### PR DESCRIPTION
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata-go/tree/master/changes).

**What this PR does**:
Intercept the `REPLACE INTO` statement in AT mode to prevent potential data inconsistency, as AT mode does not currently support it. Added corresponding unit tests to verify the interception and ensure normal execution for non-global transactions.

**Which issue(s) this PR fixes**:
Fixes #1121

@mx-gp First, I apologize for any confusion caused by closing the previous PR (#1122). I had to recreate this new PR to cleanly resolve some messy merge conflicts with the `master` branch.

Second, thank you very much for your detailed and valuable feedback! I have updated the code to address all your concerns:

1. **Resolved testability regression**: Removed `gomonkey` entirely. Switched to package-level variable reassignment combined with `t.Cleanup()` for dependency injection. This ensures test stability without requiring specific compiler flags (`-gcflags="-l"`).
2. **Added missing test cases**: 
   - Added coverage for `REPLACE INTO` executed via `ExecWithValue`.
   - Added test cases to verify that the statement *passes through* correctly when outside a global transaction (`isGlobalTx == false`).

**Does this PR introduce a user-facing change?**:
```release-note
NONE