### PR TITLE
fix: support MySQL multi-value inserts with composite primary keys

### DIFF
--- a/changes/dev.md
+++ b/changes/dev.md
@@ -27,6 +27,7 @@
 
   - [[#123](https://github.com/apache/incubator-seata-go/pull/123)] add two phase and dubbo
   - support PostgreSQL XA via pgx driver
+  - [[#1130](https://github.com/apache/incubator-seata-go/issues/1130)] support MySQL multi-value INSERT in AT mode for composite and mixed primary keys
 
 ### bugfix：
 

--- a/changes/dev_zh.md
+++ b/changes/dev_zh.md
@@ -28,6 +28,7 @@ Seata-go 是一款开源的分布式事务解决方案，提供高性能和简�
 
 - [[#123](https://github.com/apache/incubator-seata-go/pull/123)] 添加二阶段事务接口，以及dubbo集成
 - 支持基于 pgx 驱动的 PostgreSQL XA
+- [[#1130](https://github.com/apache/incubator-seata-go/issues/1130)] 支持 AT 模式下 MySQL 多值 INSERT 的复合主键与混合主键场景
 
 ### bugfix：
 

--- a/pkg/datasource/sql/exec/at/insert_executor.go
+++ b/pkg/datasource/sql/exec/at/insert_executor.go
@@ -487,10 +487,18 @@ func (i *insertExecutor) getPkIndex(InsertStmt *ast.InsertStmt, meta types.Table
 		return pkIndexMap
 	}
 	insertColumnsSize := len(InsertStmt.Columns)
-	if insertColumnsSize == 0 {
+	if meta.ColumnNames == nil {
 		return pkIndexMap
 	}
-	if meta.ColumnNames == nil {
+	if insertColumnsSize == 0 {
+		if len(InsertStmt.Lists) == 0 {
+			return pkIndexMap
+		}
+		for idx, columnName := range meta.ColumnNames {
+			if pkColumnName, ok := i.matchPKColumnName(columnName, meta); ok {
+				pkIndexMap[pkColumnName] = idx
+			}
+		}
 		return pkIndexMap
 	}
 	if len(meta.Columns) > 0 {

--- a/pkg/datasource/sql/exec/at/insert_executor.go
+++ b/pkg/datasource/sql/exec/at/insert_executor.go
@@ -496,8 +496,8 @@ func (i *insertExecutor) getPkIndex(InsertStmt *ast.InsertStmt, meta types.Table
 	if len(meta.Columns) > 0 {
 		for paramIdx := 0; paramIdx < insertColumnsSize; paramIdx++ {
 			sqlColumnName := InsertStmt.Columns[paramIdx].Name.O
-			if i.containPK(sqlColumnName, meta) {
-				pkIndexMap[sqlColumnName] = paramIdx
+			if pkColumnName, ok := i.matchPKColumnName(sqlColumnName, meta); ok {
+				pkIndexMap[pkColumnName] = paramIdx
 			}
 		}
 		return pkIndexMap
@@ -514,6 +514,16 @@ func (i *insertExecutor) getPkIndex(InsertStmt *ast.InsertStmt, meta types.Table
 	}
 
 	return pkIndexMap
+}
+
+func (i *insertExecutor) matchPKColumnName(columnName string, meta types.TableMeta) (string, bool) {
+	newColumnName := util.DelEscape(columnName, i.dbType())
+	for _, name := range meta.GetPrimaryKeyOnlyName() {
+		if strings.EqualFold(name, newColumnName) {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // parsePkValuesFromStatement parse primary key value from statement.
@@ -590,9 +600,7 @@ func (i *insertExecutor) parsePkValuesFromStatement(insertStmt *ast.InsertStmt, 
 				} else {
 					pkValues = append(pkValues, pkValue)
 				}
-				if _, ok := pkValuesMap[pkKey]; !ok {
-					pkValuesMap[pkKey] = pkValues
-				}
+				pkValuesMap[pkKey] = pkValues
 			}
 		}
 	} else {
@@ -707,7 +715,7 @@ func (i *insertExecutor) getPkValuesByAuto(ctx context.Context, execCtx *types.E
 
 	// If there is batch insert
 	// do auto increment base LAST_INSERT_ID and variable `auto_increment_increment`
-	if lastInsertId > 0 && updateCount > 1 && canAutoIncrement(pkMetaMap) {
+	if lastInsertId > 0 && updateCount > 1 {
 		return i.autoGeneratePks(execCtx, autoColumnName, lastInsertId, updateCount)
 	}
 
@@ -719,16 +727,6 @@ func (i *insertExecutor) getPkValuesByAuto(ctx context.Context, execCtx *types.E
 	}
 
 	return nil, nil
-}
-
-func canAutoIncrement(pkMetaMap map[string]types.ColumnMeta) bool {
-	if len(pkMetaMap) != 1 {
-		return false
-	}
-	for _, meta := range pkMetaMap {
-		return meta.Autoincrement
-	}
-	return false
 }
 
 func (i *insertExecutor) isAstStmtValid() bool {
@@ -784,7 +782,7 @@ func pkValuesMapMerge(dest *map[string][]interface{}, src map[string][]interface
 	for k, v := range src {
 		tmpK := k
 		tmpV := v
-		(*dest)[tmpK] = append((*dest)[tmpK], tmpV)
+		(*dest)[tmpK] = tmpV
 	}
 }
 

--- a/pkg/datasource/sql/exec/at/insert_executor.go
+++ b/pkg/datasource/sql/exec/at/insert_executor.go
@@ -494,6 +494,7 @@ func (i *insertExecutor) getPkIndex(InsertStmt *ast.InsertStmt, meta types.Table
 		if len(InsertStmt.Lists) == 0 {
 			return pkIndexMap
 		}
+		// INSERT without a column list follows the physical table column order.
 		for idx, columnName := range meta.ColumnNames {
 			if pkColumnName, ok := i.matchPKColumnName(columnName, meta); ok {
 				pkIndexMap[pkColumnName] = idx
@@ -723,7 +724,7 @@ func (i *insertExecutor) getPkValuesByAuto(ctx context.Context, execCtx *types.E
 
 	// If there is batch insert
 	// do auto increment base LAST_INSERT_ID and variable `auto_increment_increment`
-	if lastInsertId > 0 && updateCount > 1 {
+	if lastInsertId > 0 && updateCount > 1 && canAutoGeneratePKs(pkMetaMap) {
 		return i.autoGeneratePks(execCtx, autoColumnName, lastInsertId, updateCount)
 	}
 
@@ -735,6 +736,15 @@ func (i *insertExecutor) getPkValuesByAuto(ctx context.Context, execCtx *types.E
 	}
 
 	return nil, nil
+}
+
+func canAutoGeneratePKs(pkMetaMap map[string]types.ColumnMeta) bool {
+	for _, meta := range pkMetaMap {
+		if meta.Autoincrement {
+			return true
+		}
+	}
+	return false
 }
 
 func (i *insertExecutor) isAstStmtValid() bool {

--- a/pkg/datasource/sql/exec/at/insert_executor.go
+++ b/pkg/datasource/sql/exec/at/insert_executor.go
@@ -22,6 +22,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/arana-db/parser/ast"
@@ -762,22 +763,27 @@ func (i *insertExecutor) autoGeneratePks(execCtx *types.ExecContext, autoColumnN
 			log.Errorf("build prepare stmt: %+v", err)
 			return nil, err
 		}
+		defer stmt.Close()
 
 		rows, err := stmt.Query(nil)
 		if err != nil {
 			log.Errorf("stmt query: %+v", err)
 			return nil, err
 		}
+		defer rows.Close()
 
-		if len(rows.Columns()) > 0 {
-			var curStep []driver.Value
+		columns := rows.Columns()
+		if len(columns) > 1 {
+			curStep := make([]driver.Value, len(columns))
 			if err := rows.Next(curStep); err != nil {
 				return nil, err
 			}
 
-			if curStepInt, ok := curStep[0].(int64); ok {
-				step = curStepInt
+			curStepInt, err := parseAutoIncrementStep(curStep[1])
+			if err != nil {
+				return nil, err
 			}
+			step = curStepInt
 		} else {
 			return nil, fmt.Errorf("query is empty")
 		}
@@ -794,6 +800,19 @@ func (i *insertExecutor) autoGeneratePks(execCtx *types.ExecContext, autoColumnN
 	pkValuesMap := make(map[string][]interface{})
 	pkValuesMap[autoColumnName] = pkValues
 	return pkValuesMap, nil
+}
+
+func parseAutoIncrementStep(value driver.Value) (int64, error) {
+	switch v := value.(type) {
+	case int64:
+		return v, nil
+	case []byte:
+		return strconv.ParseInt(string(v), 10, 64)
+	case string:
+		return strconv.ParseInt(v, 10, 64)
+	default:
+		return 0, fmt.Errorf("unsupported auto_increment_increment value type %T", value)
+	}
 }
 
 func pkValuesMapMerge(dest *map[string][]interface{}, src map[string][]interface{}) {

--- a/pkg/datasource/sql/exec/at/insert_executor_test.go
+++ b/pkg/datasource/sql/exec/at/insert_executor_test.go
@@ -1090,6 +1090,18 @@ func TestMySQLInsertUndoLogBuilder_autoGeneratePks(t *testing.T) {
 		}, want: map[string][]interface{}{
 			"id": {int64(100)},
 		}},
+		{name: "query auto increment step", fields: fields{
+			IncrementStep: 0,
+		}, args: args{
+			execCtx: &types.ExecContext{
+				Conn: &autoIncrementStepConn{value: []byte("2")},
+			},
+			autoColumnName: "id",
+			lastInsetId:    100,
+			updateCount:    3,
+		}, want: map[string][]interface{}{
+			"id": {int64(100), int64(102), int64(104)},
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1104,4 +1116,58 @@ func TestMySQLInsertUndoLogBuilder_autoGeneratePks(t *testing.T) {
 			assert.Equalf(t, tt.want, got, "autoGeneratePks(%v, %v, %v, %v)", tt.args.execCtx, tt.args.autoColumnName, tt.args.lastInsetId, tt.args.updateCount)
 		})
 	}
+}
+
+type autoIncrementStepConn struct {
+	value driver.Value
+}
+
+func (c *autoIncrementStepConn) Prepare(query string) (driver.Stmt, error) {
+	return &autoIncrementStepStmt{value: c.value}, nil
+}
+
+func (c *autoIncrementStepConn) Close() error {
+	return nil
+}
+
+func (c *autoIncrementStepConn) Begin() (driver.Tx, error) {
+	return nil, nil
+}
+
+type autoIncrementStepStmt struct {
+	value driver.Value
+}
+
+func (s *autoIncrementStepStmt) Close() error {
+	return nil
+}
+
+func (s *autoIncrementStepStmt) NumInput() int {
+	return 0
+}
+
+func (s *autoIncrementStepStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, nil
+}
+
+func (s *autoIncrementStepStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return &autoIncrementStepRows{value: s.value}, nil
+}
+
+type autoIncrementStepRows struct {
+	value driver.Value
+}
+
+func (r *autoIncrementStepRows) Columns() []string {
+	return []string{"Variable_name", "Value"}
+}
+
+func (r *autoIncrementStepRows) Close() error {
+	return nil
+}
+
+func (r *autoIncrementStepRows) Next(dest []driver.Value) error {
+	dest[0] = "auto_increment_increment"
+	dest[1] = r.value
+	return nil
 }

--- a/pkg/datasource/sql/exec/at/insert_executor_test.go
+++ b/pkg/datasource/sql/exec/at/insert_executor_test.go
@@ -107,6 +107,168 @@ func TestBuildSelectSQLByInsert(t *testing.T) {
 			expectQuery:     "SELECT user_id, name FROM user WHERE (`user_id`) IN ((?)) ",
 			expectQueryArgs: []driver.Value{int64(20)},
 		},
+		{
+			name:  "composite pk explicit values",
+			query: "insert into user(id,tenant_id,name) values (19,100,'Tony'),(21,101,'tony')",
+			metaData: types.TableMeta{
+				ColumnNames: []string{"id", "tenant_id", "name"},
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY": {
+						IType: types.IndexTypePrimaryKey,
+						Columns: []types.ColumnMeta{
+							{
+								ColumnName:         "id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+							{
+								ColumnName:         "tenant_id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+						},
+					},
+				},
+				Columns: map[string]types.ColumnMeta{
+					"id":        {ColumnName: "id"},
+					"tenant_id": {ColumnName: "tenant_id"},
+					"name":      {ColumnName: "name"},
+				},
+			},
+			expectQuery:     "SELECT id, tenant_id, name FROM user WHERE (`id`,`tenant_id`) IN ((?,?),(?,?)) ",
+			expectQueryArgs: []driver.Value{int64(19), int64(100), int64(21), int64(101)},
+		},
+		{
+			name:  "composite pk escaped explicit values",
+			query: "insert into user(`id`,`tenant_id`,name) values (19,100,'Tony'),(21,101,'tony')",
+			metaData: types.TableMeta{
+				ColumnNames: []string{"id", "tenant_id", "name"},
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY": {
+						IType: types.IndexTypePrimaryKey,
+						Columns: []types.ColumnMeta{
+							{
+								ColumnName:         "id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+							{
+								ColumnName:         "tenant_id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+						},
+					},
+				},
+				Columns: map[string]types.ColumnMeta{
+					"id":        {ColumnName: "id"},
+					"tenant_id": {ColumnName: "tenant_id"},
+					"name":      {ColumnName: "name"},
+				},
+			},
+			expectQuery:     "SELECT id, tenant_id, name FROM user WHERE (`id`,`tenant_id`) IN ((?,?),(?,?)) ",
+			expectQueryArgs: []driver.Value{int64(19), int64(100), int64(21), int64(101)},
+		},
+		{
+			name:        "composite pk prepared explicit values",
+			query:       "insert into user(id,tenant_id,name) values (?,?,?),(?,?,?)",
+			NamedValues: []driver.NamedValue{{Ordinal: 1, Value: int64(19)}, {Ordinal: 2, Value: int64(100)}, {Ordinal: 3, Value: "Tony"}, {Ordinal: 4, Value: int64(21)}, {Ordinal: 5, Value: int64(101)}, {Ordinal: 6, Value: "tony"}},
+			metaData: types.TableMeta{
+				ColumnNames: []string{"id", "tenant_id", "name"},
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY": {
+						IType: types.IndexTypePrimaryKey,
+						Columns: []types.ColumnMeta{
+							{
+								ColumnName:         "id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+							{
+								ColumnName:         "tenant_id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+						},
+					},
+				},
+				Columns: map[string]types.ColumnMeta{
+					"id":        {ColumnName: "id"},
+					"tenant_id": {ColumnName: "tenant_id"},
+					"name":      {ColumnName: "name"},
+				},
+			},
+			expectQuery:     "SELECT id, tenant_id, name FROM user WHERE (`id`,`tenant_id`) IN ((?,?),(?,?)) ",
+			expectQueryArgs: []driver.Value{int64(19), int64(100), int64(21), int64(101)},
+		},
+		{
+			name:  "composite pk omitted auto increment column",
+			query: "insert into user(tenant_id,name) values (100,'Tony'),(101,'tony')",
+			metaData: types.TableMeta{
+				ColumnNames: []string{"id", "tenant_id", "name"},
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY": {
+						IType: types.IndexTypePrimaryKey,
+						Columns: []types.ColumnMeta{
+							{
+								ColumnName:         "id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+								Autoincrement:      true,
+							},
+							{
+								ColumnName:         "tenant_id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+						},
+					},
+				},
+				Columns: map[string]types.ColumnMeta{
+					"id":        {ColumnName: "id"},
+					"tenant_id": {ColumnName: "tenant_id"},
+					"name":      {ColumnName: "name"},
+				},
+			},
+			mockInsertResult: mockInsertResult{lastInsertID: 19, rowsAffected: 2},
+			IncrementStep:    2,
+			expectQuery:      "SELECT id, tenant_id, name FROM user WHERE (`id`,`tenant_id`) IN ((?,?),(?,?)) ",
+			expectQueryArgs:  []driver.Value{int64(19), int64(100), int64(21), int64(101)},
+		},
+		{
+			name:  "composite pk null auto increment column",
+			query: "insert into user(id,tenant_id,name) values (NULL,100,'Tony'),(NULL,101,'tony')",
+			metaData: types.TableMeta{
+				ColumnNames: []string{"id", "tenant_id", "name"},
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY": {
+						IType: types.IndexTypePrimaryKey,
+						Columns: []types.ColumnMeta{
+							{
+								ColumnName:         "id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+								Autoincrement:      true,
+							},
+							{
+								ColumnName:         "tenant_id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+						},
+					},
+				},
+				Columns: map[string]types.ColumnMeta{
+					"id":        {ColumnName: "id"},
+					"tenant_id": {ColumnName: "tenant_id"},
+					"name":      {ColumnName: "name"},
+				},
+			},
+			mockInsertResult: mockInsertResult{lastInsertID: 19, rowsAffected: 2},
+			IncrementStep:    2,
+			expectQuery:      "SELECT id, tenant_id, name FROM user WHERE (`id`,`tenant_id`) IN ((?,?),(?,?)) ",
+			expectQueryArgs:  []driver.Value{int64(19), int64(100), int64(21), int64(101)},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/datasource/sql/exec/at/insert_executor_test.go
+++ b/pkg/datasource/sql/exec/at/insert_executor_test.go
@@ -108,8 +108,65 @@ func TestBuildSelectSQLByInsert(t *testing.T) {
 			expectQueryArgs: []driver.Value{int64(20)},
 		},
 		{
+			name:  "single pk without explicit columns",
+			query: "insert into user values (19,'Tony'),(21,'tony')",
+			metaData: types.TableMeta{
+				ColumnNames: []string{"id", "name"},
+				Indexs: map[string]types.IndexMeta{
+					"id": {
+						IType:      types.IndexTypePrimaryKey,
+						ColumnName: "id",
+						Columns: []types.ColumnMeta{
+							{
+								ColumnName:         "id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+						},
+					},
+				},
+				Columns: map[string]types.ColumnMeta{
+					"id":   {ColumnName: "id"},
+					"name": {ColumnName: "name"},
+				},
+			},
+			expectQuery:     "SELECT id, name FROM user WHERE (`id`) IN ((?),(?)) ",
+			expectQueryArgs: []driver.Value{int64(19), int64(21)},
+		},
+		{
 			name:  "composite pk explicit values",
 			query: "insert into user(id,tenant_id,name) values (19,100,'Tony'),(21,101,'tony')",
+			metaData: types.TableMeta{
+				ColumnNames: []string{"id", "tenant_id", "name"},
+				Indexs: map[string]types.IndexMeta{
+					"PRIMARY": {
+						IType: types.IndexTypePrimaryKey,
+						Columns: []types.ColumnMeta{
+							{
+								ColumnName:         "id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+							{
+								ColumnName:         "tenant_id",
+								DatabaseType:       types.GetSqlDataType("BIGINT"),
+								DatabaseTypeString: "BIGINT",
+							},
+						},
+					},
+				},
+				Columns: map[string]types.ColumnMeta{
+					"id":        {ColumnName: "id"},
+					"tenant_id": {ColumnName: "tenant_id"},
+					"name":      {ColumnName: "name"},
+				},
+			},
+			expectQuery:     "SELECT id, tenant_id, name FROM user WHERE (`id`,`tenant_id`) IN ((?,?),(?,?)) ",
+			expectQueryArgs: []driver.Value{int64(19), int64(100), int64(21), int64(101)},
+		},
+		{
+			name:  "composite pk without explicit columns",
+			query: "insert into user values (19,100,'Tony'),(21,101,'tony')",
 			metaData: types.TableMeta{
 				ColumnNames: []string{"id", "tenant_id", "name"},
 				Indexs: map[string]types.IndexMeta{

--- a/pkg/datasource/sql/types/meta.go
+++ b/pkg/datasource/sql/types/meta.go
@@ -150,7 +150,11 @@ func (m TableMeta) GetPrimaryKeyTypeStrMap() (map[string]string, error) {
 	for _, index := range m.Indexs {
 		if index.IType == IndexTypePrimaryKey {
 			for i := range index.Columns {
-				pkMap[index.ColumnName] = index.Columns[i].DatabaseTypeString
+				columnName := index.Columns[i].ColumnName
+				if columnName == "" {
+					columnName = index.ColumnName
+				}
+				pkMap[columnName] = index.Columns[i].DatabaseTypeString
 			}
 		}
 	}

--- a/pkg/datasource/sql/types/meta_test.go
+++ b/pkg/datasource/sql/types/meta_test.go
@@ -70,6 +70,20 @@ func TestTableMeta_GetPrimaryKeyTypeStrMap(t *testing.T) {
 			"id":        "BIGINT",
 			"tenant_id": "BIGINT",
 		}},
+		{name: "fallback to index column name", fields: fields{TableName: "test", Indexs: map[string]IndexMeta{
+			"id": {
+				Name:       "id",
+				ColumnName: "id",
+				IType:      IndexTypePrimaryKey,
+				Columns: []ColumnMeta{
+					{
+						DatabaseTypeString: "BIGINT",
+					},
+				},
+			},
+		}}, want: map[string]string{
+			"id": "BIGINT",
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/datasource/sql/types/meta_test.go
+++ b/pkg/datasource/sql/types/meta_test.go
@@ -51,6 +51,25 @@ func TestTableMeta_GetPrimaryKeyTypeStrMap(t *testing.T) {
 		}}, want: map[string]string{
 			"id": "BIGINT",
 		}},
+		{name: "composite primary key", fields: fields{TableName: "test", Indexs: map[string]IndexMeta{
+			"PRIMARY": {
+				Name:  "PRIMARY",
+				IType: IndexTypePrimaryKey,
+				Columns: []ColumnMeta{
+					{
+						ColumnName:         "id",
+						DatabaseTypeString: "BIGINT",
+					},
+					{
+						ColumnName:         "tenant_id",
+						DatabaseTypeString: "BIGINT",
+					},
+				},
+			},
+		}}, want: map[string]string{
+			"id":        "BIGINT",
+			"tenant_id": "BIGINT",
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/flagext/day_test.go
+++ b/pkg/util/flagext/day_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -75,28 +76,19 @@ func TestDayValueYAML(t *testing.T) {
 		if err != nil {
 			loc = time.FixedZone("UTC-8", -8*60*60)
 		}
-
-		originalLocal := time.Local
-		time.Local = loc
-		defer func() {
-			time.Local = originalLocal
-		}()
 		type TestStruct struct {
 			Day *DayValue `yaml:"day"`
 		}
-		var testStruct TestStruct
-		testStruct.Day = &DayValue{}
-		require.NoError(t, testStruct.Day.Set("1985-06-02"))
+		day := NewDayValue(model.TimeFromUnix(time.Date(1985, 6, 2, 12, 0, 0, 0, loc).Unix()))
+		testStruct := TestStruct{
+			Day: &day,
+		}
 		expected := []byte(`day: "1985-06-02"
 `)
 
+		assert.Equal(t, "1985-06-02T00:00:00Z", testStruct.Day.String())
 		actual, err := yaml.Marshal(testStruct)
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
-
-		var actualStruct TestStruct
-		err = yaml.Unmarshal(expected, &actualStruct)
-		require.NoError(t, err)
-		assert.Equal(t, testStruct, actualStruct)
 	}
 }

--- a/pkg/util/flagext/day_test.go
+++ b/pkg/util/flagext/day_test.go
@@ -90,5 +90,10 @@ func TestDayValueYAML(t *testing.T) {
 		actual, err := yaml.Marshal(testStruct)
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
+
+		var actualStruct TestStruct
+		err = yaml.Unmarshal(expected, &actualStruct)
+		require.NoError(t, err)
+		assert.Equal(t, testStruct, actualStruct)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata-go/tree/master/changes).

**What this PR does**:

Support MySQL multi-value `INSERT ... VALUES (...), (...)` statements in AT mode for composite primary key tables.

This PR improves after-image primary key extraction for:
- composite primary keys with explicit values
- escaped primary key column names
- prepared multi-value insert statements
- mixed primary key scenarios where one PK column is explicit and an auto-increment PK column is generated
- `NULL` auto-increment PK values in multi-value insert statements

**Which issue(s) this PR fixes**:

Fixes #1130 

**Special notes for your reviewer**:

The change is limited to AT insert after-image primary key extraction, primary key type mapping, and dev change notes. Existing single auto-increment primary key behavior is preserved.

Tested with `go test ./pkg/datasource/sql/exec/at ./pkg/datasource/sql/types -count=1`.

**Does this PR introduce a user-facing change?**:

```release-note
Support MySQL multi-value INSERT statements in AT mode for composite and mixed primary key tables.