### PR TITLE
fix: preserve XA retry state and connection ownership

### DIFF
--- a/changes/dev.md
+++ b/changes/dev.md
@@ -32,6 +32,7 @@
 
 ### bugfix：
 
+  - [[#1147](https://github.com/apache/incubator-seata-go/issues/1147)] fix XA failure-path status, retry, idempotency, and held-connection ownership
   - [[#904](https://github.com/apache/incubator-seata-go/issues/904)] fix "busy buffer" / "driver: bad connection" when a `SELECT ... FOR UPDATE` is followed by another statement under XA autoCommit, by deferring the branch commit (XA END + XA PREPARE) until the query rows are closed
   - [[#130](https://github.com/apache/incubator-seata-go/pull/130)] getty session auto close bug
   - [[#991](https://github.com/apache/incubator-seata-go/issues/991)] fix connection leaks and prevent nil pointer panic in async worker

--- a/changes/dev_zh.md
+++ b/changes/dev_zh.md
@@ -33,6 +33,7 @@ Seata-go 是一款开源的分布式事务解决方案，提供高性能和简�
 
 ### bugfix：
 
+- [[#1147](https://github.com/apache/incubator-seata-go/issues/1147)] 修复 XA 失败路径中的状态、重试、幂等与连接持有权问题
 - [[#904](https://github.com/apache/incubator-seata-go/issues/904)] 修复 XA autoCommit 下 `SELECT ... FOR UPDATE` 后紧接其他语句导致的 "busy buffer" / "driver: bad connection"：将分支提交（XA END + XA PREPARE）延迟到查询结果集关闭之后再执行
 - [[#130](https://github.com/apache/incubator-seata-go/pull/130)] 修复getty session自动关闭的bug
 

--- a/pkg/datasource/sql/conn_xa.go
+++ b/pkg/datasource/sql/conn_xa.go
@@ -43,19 +43,21 @@ var errXABranchLifecycleManaged = errors.New("xa branch lifecycle is managed by 
 type XAConn struct {
 	*Conn
 
-	tx                 driver.Tx
-	xaResource         xa.XAResource
-	xaErrorClassifier  xa.XAErrorClassifier
-	xaBranchXid        *XABranchXid
-	xaActive           bool
-	rollBacked         bool
-	branchRegisterTime time.Time
-	prepareTime        time.Time
-	keeperMu           sync.Mutex
-	shouldBeHeld       bool
-	isConnKept         bool
-	poolDiscarded      bool
-	physicalClosed     bool
+	tx                  driver.Tx
+	xaResource          xa.XAResource
+	xaErrorClassifier   xa.XAErrorClassifier
+	xaBranchXid         *XABranchXid
+	xaActive            bool
+	rollBacked          bool
+	branchRegisterTime  time.Time
+	prepareTime         time.Time
+	keeperMu            sync.Mutex
+	keepInKeeper        bool
+	shouldBeHeld        bool
+	isConnKept          bool
+	preparedForPhaseTwo bool
+	poolDiscarded       bool
+	physicalClosed      bool
 }
 
 // xaBranchTx is a sentinel driver.Tx used to satisfy database/sql wiring while
@@ -439,6 +441,7 @@ func (c *XAConn) isKept() bool {
 }
 
 func (c *XAConn) configureConnectionHold(ctx context.Context) {
+	c.keepInKeeper = c.res.keepInKeeper
 	c.shouldBeHeld = c.res.IsShouldBeHeld()
 	if !c.res.probeXADetachOnPrepare {
 		return
@@ -461,7 +464,7 @@ func (c *XAConn) keepIfNecessary() {
 	if c.xaBranchXid == nil {
 		return
 	}
-	if c.ShouldBeHeld() {
+	if c.keepInKeeper {
 		if err := c.res.Hold(c.xaBranchXid.String(), c); err == nil {
 			c.isConnKept = true
 		}
@@ -544,6 +547,7 @@ func (c *XAConn) cleanXABranchContextLocked() {
 	h, _ := time.ParseDuration("-1000h")
 	c.branchRegisterTime = time.Now().Add(h)
 	c.prepareTime = time.Now().Add(h)
+	c.preparedForPhaseTwo = false
 	c.xaActive = false
 	if !c.isConnKept {
 		c.xaBranchXid = nil
@@ -610,16 +614,16 @@ func (c *XAConn) Commit(ctx context.Context) error {
 		return c.commitErrorHandle(ctx, err)
 	}
 
+	c.keeperMu.Lock()
 	c.prepareTime = time.Now()
+	c.preparedForPhaseTwo = true
 
 	// Phase-1 is done: this session no longer has an in-flight XA branch. Clear
-	// only the session-active flag so a subsequent autoCommit statement on the
-	// same (possibly pooled/reused) connection can open a fresh branch instead of
-	// tripping the "xa branch is active" guard in BeginTx. The branch itself is
-	// still prepared and, when held, retrievable for phase-2 via xaBranchXid, so
-	// we must NOT call cleanXABranchContext here (that would reset prepareTime and
-	// drop xaBranchXid). Phase-2 XaCommit/XaRollback do not depend on xaActive.
+	// only the session-active flag so a subsequent autoCommit statement on a
+	// connection that was not transferred to the keeper can open a fresh branch.
+	// Held and temporarily cached branches remain addressable for phase two.
 	c.xaActive = false
+	c.keeperMu.Unlock()
 
 	return nil
 }
@@ -640,6 +644,12 @@ func (c *XAConn) ShouldBeHeld() bool {
 	return c.shouldBeHeld
 }
 
+func (c *XAConn) phaseTwoTimeoutSnapshot() (prepared bool, holdUntilPhaseTwo bool, preparedAt time.Time) {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+	return c.preparedForPhaseTwo, c.shouldBeHeld, c.prepareTime
+}
+
 func (c *XAConn) checkTimeout(ctx context.Context, now time.Time) error {
 	if now.Sub(c.branchRegisterTime) > xaConnTimeout {
 		c.XaRollback(ctx, c.xaBranchXid)
@@ -653,7 +663,7 @@ func (c *XAConn) Close() error {
 	defer c.keeperMu.Unlock()
 
 	c.rollBacked = false
-	if c.isConnKept && c.ShouldBeHeld() {
+	if c.isConnKept {
 		c.poolDiscarded = true
 		return nil
 	}
@@ -733,6 +743,7 @@ func (c *XAConn) completePhaseTwoWith(beforeRelease func()) {
 
 func (c *XAConn) completePhaseTwoLocked() {
 	c.releaseIfNecessaryLocked()
+	c.preparedForPhaseTwo = false
 	if c.poolDiscarded {
 		if err := c.closePhysicalLocked(); err != nil {
 			log.Errorf("close discarded XA connection after phase two: %v", err)

--- a/pkg/datasource/sql/conn_xa.go
+++ b/pkg/datasource/sql/conn_xa.go
@@ -23,10 +23,12 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/types"
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/xa"
+	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/tm"
 	"seata.apache.org/seata-go/v2/pkg/util/log"
 )
@@ -48,7 +50,11 @@ type XAConn struct {
 	rollBacked         bool
 	branchRegisterTime time.Time
 	prepareTime        time.Time
+	keeperMu           sync.Mutex
+	shouldBeHeld       bool
 	isConnKept         bool
+	poolDiscarded      bool
+	physicalClosed     bool
 }
 
 // xaBranchTx is a sentinel driver.Tx used to satisfy database/sql wiring while
@@ -174,9 +180,11 @@ func (c *XAConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx,
 	}
 
 	c.xaBranchXid = XaIdBuild(c.txCtx.XID, c.txCtx.BranchID)
+	c.configureConnectionHold(ctx)
 	c.keepIfNecessary()
 
 	if err = c.start(ctx); err != nil {
+		c.releaseIfNecessary()
 		c.cleanXABranchContext()
 		return nil, fmt.Errorf("failed to start xa branch xid:%s err:%w", c.txCtx.XID, err)
 	}
@@ -411,11 +419,44 @@ func (t xaDeferredCommitTx) Rollback() error {
 // leaves a stale flag. xaBranchXid is intentionally left untouched so a held
 // branch remains available for phase-2.
 func (c *XAConn) ResetSession(ctx context.Context) error {
+	c.keeperMu.Lock()
 	c.xaActive = false
+	if c.physicalClosed || c.isConnKept {
+		c.poolDiscarded = true
+		c.keeperMu.Unlock()
+		return driver.ErrBadConn
+	}
+	c.keeperMu.Unlock()
+
 	return c.Conn.ResetSession(ctx)
 }
 
+func (c *XAConn) isKept() bool {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+	return c.isConnKept
+}
+
+func (c *XAConn) configureConnectionHold(ctx context.Context) {
+	c.shouldBeHeld = c.res.IsShouldBeHeld()
+	if !c.res.probeXADetachOnPrepare {
+		return
+	}
+
+	detachOnPrepare, err := selectMySQLXADetachOnPrepare(ctx, c.Conn.targetConn)
+	if err != nil {
+		// The safe fallback is to retain the actual owner connection.
+		c.shouldBeHeld = true
+		log.Errorf("probe xa_detach_on_prepare on XA connection: %v", err)
+		return
+	}
+	c.shouldBeHeld = !detachOnPrepare
+}
+
 func (c *XAConn) keepIfNecessary() {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+
 	if c.xaBranchXid == nil {
 		return
 	}
@@ -427,20 +468,18 @@ func (c *XAConn) keepIfNecessary() {
 }
 
 func (c *XAConn) releaseIfNecessary() {
-	// cleanXABranchContext nils xaBranchXid once a branch is no longer kept, and
-	// the two-phase timeout checker force-closes committed connections after the
-	// hold time elapses. Guard against the nil branch xid so that sweep (which
-	// calls CloseForce -> cleanXABranchContext -> releaseIfNecessary) does not
-	// dereference a nil *XABranchXid via String().
-	if c.xaBranchXid == nil {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+	c.releaseIfNecessaryLocked()
+}
+
+func (c *XAConn) releaseIfNecessaryLocked() {
+	if !c.isConnKept || c.xaBranchXid == nil {
 		return
 	}
-	if c.ShouldBeHeld() && c.xaBranchXid.String() != "" {
-		if c.isConnKept {
-			c.res.Release(c.xaBranchXid.String())
-			c.isConnKept = false
-		}
-	}
+
+	c.res.Release(c.xaBranchXid.String())
+	c.isConnKept = false
 }
 
 func (c *XAConn) start(ctx context.Context) error {
@@ -476,15 +515,31 @@ func (c *XAConn) end(ctx context.Context, flags int) error {
 }
 
 func (c *XAConn) termination(xaBranchXid string) error {
-	branchStatus, err := branchStatus(xaBranchXid)
+	status, err := branchStatus(xaBranchXid)
 	if err != nil {
-		c.releaseIfNecessary()
-		return fmt.Errorf("failed xa branch [%v] the global transaction has finish, branch status: [%v]", c.txCtx.XID, branchStatus)
+		return fmt.Errorf("get XA branch status for [%s]: %w", xaBranchXid, err)
 	}
+
+	switch status {
+	case branch.BranchStatusPhasetwoCommitted, branch.BranchStatusPhasetwoRollbacked:
+		c.releaseIfNecessary()
+		return fmt.Errorf(
+			"XA branch [%v] has already terminated, branch status: [%v]",
+			c.txCtx.XID,
+			status,
+		)
+	}
+
 	return nil
 }
 
 func (c *XAConn) cleanXABranchContext() {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+	c.cleanXABranchContextLocked()
+}
+
+func (c *XAConn) cleanXABranchContextLocked() {
 	h, _ := time.ParseDuration("-1000h")
 	c.branchRegisterTime = time.Now().Add(h)
 	c.prepareTime = time.Now().Add(h)
@@ -542,16 +597,16 @@ func (c *XAConn) Commit(ctx context.Context) error {
 
 	now := time.Now()
 
-	if c.end(ctx, xa.TMSuccess) != nil {
-		return c.commitErrorHandle(ctx)
+	if err := c.end(ctx, xa.TMSuccess); err != nil {
+		return c.commitErrorHandle(ctx, err)
 	}
 
-	if c.checkTimeout(ctx, now) != nil {
-		return c.commitErrorHandle(ctx)
+	if err := c.checkTimeout(ctx, now); err != nil {
+		return c.commitErrorHandle(ctx, err)
 	}
 
-	if c.xaResource.XAPrepare(ctx, c.xaBranchXid.String()) != nil {
-		return c.commitErrorHandle(ctx)
+	if err := c.xaResource.XAPrepare(ctx, c.xaBranchXid.String()); err != nil {
+		return c.commitErrorHandle(ctx, err)
 	}
 
 	c.prepareTime = time.Now()
@@ -568,17 +623,20 @@ func (c *XAConn) Commit(ctx context.Context) error {
 	return nil
 }
 
-func (c *XAConn) commitErrorHandle(ctx context.Context) error {
-	var err error
-	if err = c.XaRollback(ctx, c.xaBranchXid); err != nil {
-		err = fmt.Errorf("failed to report XA branch commit-failure xid:%s, err:%w", c.txCtx.XID, err)
+func (c *XAConn) commitErrorHandle(ctx context.Context, cause error) error {
+	err := cause
+	if rollbackErr := c.XaRollback(ctx, c.xaBranchXid); rollbackErr != nil {
+		err = errors.Join(
+			cause,
+			fmt.Errorf("failed to rollback XA branch after commit failure xid:%s, err:%w", c.txCtx.XID, rollbackErr),
+		)
 	}
 	c.cleanXABranchContext()
 	return err
 }
 
 func (c *XAConn) ShouldBeHeld() bool {
-	return c.res.IsShouldBeHeld() || (c.res.GetDbType().String() != "" && c.res.GetDbType() != types.DBTypeUnknown)
+	return c.shouldBeHeld
 }
 
 func (c *XAConn) checkTimeout(ctx context.Context, now time.Time) error {
@@ -590,31 +648,47 @@ func (c *XAConn) checkTimeout(ctx context.Context, now time.Time) error {
 }
 
 func (c *XAConn) Close() error {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+
 	c.rollBacked = false
 	if c.isConnKept && c.ShouldBeHeld() {
+		c.poolDiscarded = true
 		return nil
 	}
-	c.cleanXABranchContext()
-	// Check if Conn is nil before calling Close
-	if c.Conn == nil {
-		return nil
-	}
-	return c.Conn.Close()
+	c.cleanXABranchContextLocked()
+	return c.closePhysicalLocked()
 }
 
 func (c *XAConn) CloseForce() error {
-	if err := c.Conn.Close(); err != nil {
-		return err
-	}
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+
+	err := c.closePhysicalLocked()
 	c.rollBacked = false
-	c.cleanXABranchContext()
-	c.releaseIfNecessary()
-	return nil
+	c.releaseIfNecessaryLocked()
+	c.cleanXABranchContextLocked()
+	return err
 }
 
 func (c *XAConn) XaCommit(ctx context.Context, xaXid XAXid) error {
+	return c.xaCommit(ctx, xaXid, nil)
+}
+
+func (c *XAConn) xaCommit(ctx context.Context, xaXid XAXid, beforeRelease func()) error {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+
+	if c.physicalClosed {
+		return driver.ErrBadConn
+	}
 	err := c.xaResource.Commit(ctx, xaXid.String(), false)
-	c.releaseIfNecessary()
+	if err == nil {
+		if beforeRelease != nil {
+			beforeRelease()
+		}
+		c.completePhaseTwoLocked()
+	}
 	return err
 }
 
@@ -623,7 +697,55 @@ func (c *XAConn) XaRollbackByBranchId(ctx context.Context, xaXid XAXid) error {
 }
 
 func (c *XAConn) XaRollback(ctx context.Context, xaXid XAXid) error {
+	return c.xaRollback(ctx, xaXid, nil)
+}
+
+func (c *XAConn) xaRollback(ctx context.Context, xaXid XAXid, beforeRelease func()) error {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+
+	if c.physicalClosed {
+		return driver.ErrBadConn
+	}
 	err := c.xaResource.Rollback(ctx, xaXid.String())
-	c.releaseIfNecessary()
+	if err == nil {
+		if beforeRelease != nil {
+			beforeRelease()
+		}
+		c.completePhaseTwoLocked()
+	}
 	return err
+}
+
+func (c *XAConn) completePhaseTwo() {
+	c.completePhaseTwoWith(nil)
+}
+
+func (c *XAConn) completePhaseTwoWith(beforeRelease func()) {
+	c.keeperMu.Lock()
+	defer c.keeperMu.Unlock()
+	if beforeRelease != nil {
+		beforeRelease()
+	}
+	c.completePhaseTwoLocked()
+}
+
+func (c *XAConn) completePhaseTwoLocked() {
+	c.releaseIfNecessaryLocked()
+	if c.poolDiscarded {
+		if err := c.closePhysicalLocked(); err != nil {
+			log.Errorf("close discarded XA connection after phase two: %v", err)
+		}
+	}
+}
+
+func (c *XAConn) closePhysicalLocked() error {
+	if c.physicalClosed {
+		return nil
+	}
+	c.physicalClosed = true
+	if c.Conn == nil {
+		return nil
+	}
+	return c.Conn.Close()
 }

--- a/pkg/datasource/sql/conn_xa_test.go
+++ b/pkg/datasource/sql/conn_xa_test.go
@@ -158,8 +158,45 @@ func (s *fakePreparedStmt) QueryContext(ctx context.Context, args []driver.Named
 	return rows, nil
 }
 
+type closeErrorDriverConn struct {
+	err        error
+	closeCalls int32
+	resetCalls int32
+}
+
+func (c *closeErrorDriverConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (c *closeErrorDriverConn) Close() error {
+	atomic.AddInt32(&c.closeCalls, 1)
+	return c.err
+}
+
+func (c *closeErrorDriverConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not supported")
+}
+
+func (c *closeErrorDriverConn) ResetSession(ctx context.Context) error {
+	atomic.AddInt32(&c.resetCalls, 1)
+	return nil
+}
+
+type blockingPhaseTwoXAResource struct {
+	phaseTwoTestXAResource
+	started chan struct{}
+	proceed chan struct{}
+}
+
+func (r *blockingPhaseTwoXAResource) Commit(ctx context.Context, xid string, onePhase bool) error {
+	close(r.started)
+	<-r.proceed
+	return nil
+}
+
 func baseMockConn(mockConn *mock.MockTestDriverConn) {
 	branchStatusCache = gcache.New(1024).LRU().Expiration(time.Minute * 10).Build()
+	xaConnTimeout = time.Minute
 
 	mockConn.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
 		func(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -197,6 +234,145 @@ func baseMockConn(mockConn *mock.MockTestDriverConn) {
 			}
 			return rows, nil
 		})
+}
+
+func TestDBResource_CheckDBVersionUsesEffectiveXADetachSetting(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		detachValue driver.Value
+		queryErr    error
+		expectQuery bool
+		wantHeld    bool
+		wantProbe   bool
+		wantErr     bool
+	}{
+		{
+			name:     "mysql before 8.0.29 always keeps owner",
+			version:  "8.0.28",
+			wantHeld: true,
+		},
+		{
+			name:        "detach enabled allows new connection phase two",
+			version:     "8.0.29",
+			detachValue: []byte("1"),
+			expectQuery: true,
+			wantHeld:    false,
+			wantProbe:   true,
+		},
+		{
+			name:        "detach disabled keeps owner",
+			version:     "8.0.29",
+			detachValue: "OFF",
+			expectQuery: true,
+			wantHeld:    true,
+			wantProbe:   true,
+		},
+		{
+			name:        "probe failure falls back to keeping owner",
+			version:     "8.0.29",
+			queryErr:    errors.New("permission denied"),
+			expectQuery: true,
+			wantHeld:    true,
+			wantProbe:   true,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockConn := mock.NewMockTestDriverConn(ctrl)
+			if tt.expectQuery {
+				call := mockConn.EXPECT().QueryContext(
+					gomock.Any(),
+					"SELECT @@session.xa_detach_on_prepare",
+					gomock.Any(),
+				)
+				if tt.queryErr != nil {
+					call.Return(nil, tt.queryErr)
+				} else {
+					call.Return(&mysqlMockRows{data: [][]interface{}{{tt.detachValue}}}, nil)
+				}
+			}
+
+			resource := &DBResource{
+				dbType:    types.DBTypeMySQL,
+				dbVersion: tt.version,
+			}
+			err := resource.checkDbVersion(context.Background(), mockConn)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantHeld, resource.shouldBeHeld)
+			assert.Equal(t, tt.wantProbe, resource.probeXADetachOnPrepare)
+		})
+	}
+}
+
+func TestXAConn_ConfigureConnectionHoldUsesActualSessionSetting(t *testing.T) {
+	tests := []struct {
+		name        string
+		detachValue driver.Value
+		queryErr    error
+		wantHeld    bool
+	}{
+		{
+			name:        "actual session detach enabled",
+			detachValue: int64(1),
+			wantHeld:    false,
+		},
+		{
+			name:        "actual session detach disabled",
+			detachValue: int64(0),
+			wantHeld:    true,
+		},
+		{
+			name:     "actual session probe failure is conservative",
+			queryErr: errors.New("session variable unavailable"),
+			wantHeld: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockConn := mock.NewMockTestDriverConn(ctrl)
+			call := mockConn.EXPECT().QueryContext(
+				gomock.Any(),
+				"SELECT @@session.xa_detach_on_prepare",
+				gomock.Any(),
+			)
+			if tt.queryErr != nil {
+				call.Return(nil, tt.queryErr)
+			} else {
+				call.Return(&mysqlMockRows{data: [][]interface{}{{tt.detachValue}}}, nil)
+			}
+
+			resource := &DBResource{
+				dbType:                 types.DBTypeMySQL,
+				probeXADetachOnPrepare: true,
+			}
+			xaConn := &XAConn{
+				Conn: &Conn{
+					targetConn: mockConn,
+					res:        resource,
+					dbType:     types.DBTypeMySQL,
+				},
+			}
+
+			xaConn.configureConnectionHold(context.Background())
+
+			assert.Equal(t, tt.wantHeld, xaConn.ShouldBeHeld())
+		})
+	}
 }
 
 func initXAConnTestResource(t *testing.T) (*gomock.Controller, *sql.DB, *mockSQLInterceptor, *mockTxHook) {
@@ -259,6 +435,224 @@ func newMockXAConn(t *testing.T, ctrl *gomock.Controller, branchID int64) (*XACo
 			dbType:     types.DBTypeMySQL,
 		},
 	}, mockMgr
+}
+
+func TestXAConn_CommitPreservesPrepareErrorAfterCompensatingRollback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	xaConn, _ := newMockXAConn(t, ctrl, 123)
+	xaConn.autoCommit = false
+	xaConn.xaActive = true
+	xaConn.txCtx.XID = "127.0.0.1:8091:1001"
+	xaConn.txCtx.BranchID = 123
+	xaConn.xaBranchXid = XaIdBuild(xaConn.txCtx.XID, uint64(xaConn.txCtx.BranchID))
+	xaConn.xaResource = &xa.MysqlXAConn{Conn: xaConn.Conn.targetConn}
+	xaConn.xaErrorClassifier = &xa.MysqlXAErrorClassifier{}
+	xaConn.branchRegisterTime = time.Now()
+
+	previousTimeout := xaConnTimeout
+	xaConnTimeout = time.Minute
+	defer func() {
+		xaConnTimeout = previousTimeout
+		simulateExecContextError = nil
+	}()
+
+	prepareErr := errors.New("prepare failed after XA END")
+	simulateExecContextError = func(query string) error {
+		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "XA PREPARE") {
+			return prepareErr
+		}
+		return nil
+	}
+
+	err := xaConn.Commit(context.Background())
+
+	assert.ErrorIs(t, err, prepareErr)
+	assert.Contains(t, err.Error(), "prepare failed after XA END")
+}
+
+func TestXAConn_CloseForceReleasesKeeperWhenPhysicalCloseFails(t *testing.T) {
+	closeErr := errors.New("physical close failed")
+	xaID := XaIdBuild("127.0.0.1:8091:1001", 123)
+	resource := &DBResource{dbType: types.DBTypeMySQL, shouldBeHeld: true}
+	xaConn := &XAConn{
+		Conn: &Conn{
+			targetConn: &closeErrorDriverConn{err: closeErr},
+			res:        resource,
+			dbType:     types.DBTypeMySQL,
+		},
+		xaBranchXid:  xaID,
+		xaActive:     true,
+		shouldBeHeld: true,
+		isConnKept:   true,
+	}
+	assert.NoError(t, resource.Hold(xaID.String(), xaConn))
+
+	err := xaConn.CloseForce()
+
+	assert.ErrorIs(t, err, closeErr)
+	_, held := resource.Lookup(xaID.String())
+	assert.False(t, held)
+	assert.False(t, xaConn.isConnKept)
+	assert.False(t, xaConn.xaActive)
+}
+
+func TestXAConn_HeldConnectionTransfersOwnershipFromPoolToKeeper(t *testing.T) {
+	underlying := &closeErrorDriverConn{}
+	xaID := XaIdBuild("127.0.0.1:8091:1001", 123)
+	resource := &DBResource{dbType: types.DBTypeMySQL, shouldBeHeld: true}
+	xaConn := &XAConn{
+		Conn: &Conn{
+			targetConn: underlying,
+			res:        resource,
+			dbType:     types.DBTypeMySQL,
+		},
+		xaResource:     &phaseTwoTestXAResource{},
+		xaBranchXid:    xaID,
+		shouldBeHeld:   true,
+		isConnKept:     true,
+		prepareTime:    time.Now(),
+		physicalClosed: false,
+	}
+	assert.NoError(t, resource.Hold(xaID.String(), xaConn))
+
+	assert.ErrorIs(t, xaConn.ResetSession(context.Background()), driver.ErrBadConn)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&underlying.resetCalls))
+
+	assert.NoError(t, xaConn.Close())
+	assert.Equal(t, int32(0), atomic.LoadInt32(&underlying.closeCalls))
+	_, heldBeforePhaseTwo := resource.Lookup(xaID.String())
+	assert.True(t, heldBeforePhaseTwo)
+
+	assert.NoError(t, xaConn.XaCommit(context.Background(), xaID))
+	_, heldAfterPhaseTwo := resource.Lookup(xaID.String())
+	assert.False(t, heldAfterPhaseTwo)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&underlying.closeCalls))
+	assert.ErrorIs(t, xaConn.ResetSession(context.Background()), driver.ErrBadConn)
+}
+
+func TestXAConn_PhaseTwoAndTimeoutCloseHaveSinglePhysicalOwner(t *testing.T) {
+	underlying := &closeErrorDriverConn{}
+	xaID := XaIdBuild("127.0.0.1:8091:1001", 123)
+	resource := &DBResource{dbType: types.DBTypeMySQL, shouldBeHeld: true}
+	xaResource := &blockingPhaseTwoXAResource{
+		started: make(chan struct{}),
+		proceed: make(chan struct{}),
+	}
+	xaConn := &XAConn{
+		Conn: &Conn{
+			targetConn: underlying,
+			res:        resource,
+			dbType:     types.DBTypeMySQL,
+		},
+		xaResource:   xaResource,
+		xaBranchXid:  xaID,
+		shouldBeHeld: true,
+		isConnKept:   true,
+		prepareTime:  time.Now(),
+	}
+	assert.NoError(t, resource.Hold(xaID.String(), xaConn))
+	assert.ErrorIs(t, xaConn.ResetSession(context.Background()), driver.ErrBadConn)
+	assert.NoError(t, xaConn.Close())
+
+	commitDone := make(chan error, 1)
+	go func() {
+		commitDone <- xaConn.XaCommit(context.Background(), xaID)
+	}()
+	<-xaResource.started
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- xaConn.CloseForce()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("timeout close raced ahead of phase two: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(xaResource.proceed)
+	assert.NoError(t, <-commitDone)
+	assert.NoError(t, <-closeDone)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&underlying.closeCalls))
+	_, held := resource.Lookup(xaID.String())
+	assert.False(t, held)
+}
+
+func TestXAConn_BeginTxReleasesKeeperWhenXAStartFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	xaConn, _ := newMockXAConn(t, ctrl, 123)
+	xaConn.res.shouldBeHeld = true
+
+	defer func() {
+		simulateExecContextError = nil
+	}()
+	startErr := errors.New("XA START failed")
+	simulateExecContextError = func(query string) error {
+		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "XA START") {
+			return startErr
+		}
+		return nil
+	}
+
+	ctx := tm.InitSeataContext(context.Background())
+	tm.SetXID(ctx, "127.0.0.1:8091:1001")
+	_, err := xaConn.BeginTx(ctx, driver.TxOptions{})
+
+	assert.ErrorIs(t, err, startErr)
+	xaID := XaIdBuild(tm.GetXID(ctx), 123)
+	_, held := xaConn.res.Lookup(xaID.String())
+	assert.False(t, held)
+	assert.False(t, xaConn.isKept())
+}
+
+func TestXAConn_TerminationRejectsCachedTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status branch.BranchStatus
+	}{
+		{
+			name:   "committed",
+			status: branch.BranchStatusPhasetwoCommitted,
+		},
+		{
+			name:   "rollbacked",
+			status: branch.BranchStatusPhasetwoRollbacked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			branchStatusCache = gcache.New(16).LRU().Expiration(time.Minute).Build()
+			xaID := XaIdBuild("127.0.0.1:8091:1001", 123)
+			resource := &DBResource{dbType: types.DBTypeMySQL, shouldBeHeld: true}
+			xaConn := &XAConn{
+				Conn: &Conn{
+					res:   resource,
+					txCtx: types.NewTxCtx(),
+				},
+				xaBranchXid:  xaID,
+				shouldBeHeld: true,
+				isConnKept:   true,
+			}
+			xaConn.txCtx.XID = xaID.GetGlobalXid()
+			assert.NoError(t, resource.Hold(xaID.String(), xaConn))
+			setBranchStatus(xaID.String(), tt.status)
+
+			err := xaConn.termination(xaID.String())
+
+			assert.Error(t, err)
+			if err != nil {
+				assert.Contains(t, err.Error(), tt.status.String())
+			}
+			_, held := resource.Lookup(xaID.String())
+			assert.False(t, held)
+		})
+	}
 }
 
 func TestXAConn_ExecContext(t *testing.T) {

--- a/pkg/datasource/sql/db.go
+++ b/pkg/datasource/sql/db.go
@@ -22,6 +22,8 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"io"
+	"strings"
 	"sync"
 
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/datasource"
@@ -115,9 +117,10 @@ type DBResource struct {
 	branchType branch.BranchType
 
 	// for xa
-	metaCache    datasource.TableMetaCache
-	shouldBeHeld bool
-	keeper       sync.Map // xaBranchID -> *XAConn
+	metaCache              datasource.TableMetaCache
+	shouldBeHeld           bool
+	probeXADetachOnPrepare bool
+	keeper                 sync.Map // xaBranchID -> *XAConn
 }
 
 func (db *DBResource) GetResourceGroupId() string {
@@ -137,7 +140,9 @@ func (db *DBResource) init() {
 		log.Errorf("select db version: %v", err)
 	}
 	db.SetDbVersion(version)
-	db.checkDbVersion()
+	if err := db.checkDbVersion(ctx, conn); err != nil {
+		log.Errorf("check db version and XA capabilities: %v", err)
+	}
 }
 
 func (db *DBResource) GetResourceId() string {
@@ -237,9 +242,13 @@ func (db *DBResource) ConnectionForXA(ctx context.Context, xaXid XAXid) (*XAConn
 	return xaConn, nil
 }
 
-func (db *DBResource) checkDbVersion() error {
+func (db *DBResource) checkDbVersion(ctx context.Context, conn driver.Conn) error {
 	switch db.dbType {
 	case types.DBTypeMySQL:
+		// Conservatively keep the owner unless both the version and the effective
+		// session variable prove that cross-connection phase two is supported.
+		db.shouldBeHeld = true
+
 		currentVersion, err := util.ConvertDbVersion(db.dbVersion)
 		if err != nil {
 			return fmt.Errorf("new connection xa proxy convert db version:%s err:%v", db.GetDbVersion(), err)
@@ -250,11 +259,73 @@ func (db *DBResource) checkDbVersion() error {
 			return fmt.Errorf("new connection xa proxy convert db version 8.0.29 err:%v", err)
 		}
 
-		if currentVersion < shouldKeptVersion {
-			db.shouldBeHeld = true
+		if currentVersion >= shouldKeptVersion {
+			db.probeXADetachOnPrepare = true
+			detachOnPrepare, err := selectMySQLXADetachOnPrepare(ctx, conn)
+			if err != nil {
+				return err
+			}
+			db.shouldBeHeld = !detachOnPrepare
 		}
 	case types.DBTypeMARIADB:
 		db.shouldBeHeld = true
 	}
 	return nil
+}
+
+func selectMySQLXADetachOnPrepare(ctx context.Context, conn driver.Conn) (bool, error) {
+	var (
+		rows driver.Rows
+		err  error
+	)
+
+	queryerCtx, ok := conn.(driver.QueryerContext)
+	var queryer driver.Queryer
+	if !ok {
+		queryer, ok = conn.(driver.Queryer)
+	}
+	if !ok {
+		return false, fmt.Errorf("target conn should implement driver.QueryerContext or driver.Queryer")
+	}
+
+	rows, err = util.CtxDriverQuery(ctx, queryerCtx, queryer, "SELECT @@session.xa_detach_on_prepare", nil)
+	if err != nil {
+		return false, fmt.Errorf("query xa_detach_on_prepare: %w", err)
+	}
+	defer rows.Close()
+
+	dest := make([]driver.Value, 1)
+	if err = rows.Next(dest); err != nil {
+		if err == io.EOF {
+			return false, fmt.Errorf("query xa_detach_on_prepare returned no rows")
+		}
+		return false, fmt.Errorf("read xa_detach_on_prepare: %w", err)
+	}
+
+	var value string
+	switch typed := dest[0].(type) {
+	case int64:
+		if typed == 0 {
+			return false, nil
+		}
+		if typed == 1 {
+			return true, nil
+		}
+		return false, fmt.Errorf("unexpected xa_detach_on_prepare value: %d", typed)
+	case []byte:
+		value = string(typed)
+	case string:
+		value = typed
+	default:
+		return false, fmt.Errorf("unexpected xa_detach_on_prepare type: %T", dest[0])
+	}
+
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "on", "true":
+		return true, nil
+	case "0", "off", "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected xa_detach_on_prepare value: %q", value)
+	}
 }

--- a/pkg/datasource/sql/db.go
+++ b/pkg/datasource/sql/db.go
@@ -118,6 +118,7 @@ type DBResource struct {
 
 	// for xa
 	metaCache              datasource.TableMetaCache
+	keepInKeeper           bool
 	shouldBeHeld           bool
 	probeXADetachOnPrepare bool
 	keeper                 sync.Map // xaBranchID -> *XAConn
@@ -140,8 +141,10 @@ func (db *DBResource) init() {
 		log.Errorf("select db version: %v", err)
 	}
 	db.SetDbVersion(version)
-	if err := db.checkDbVersion(ctx, conn); err != nil {
-		log.Errorf("check db version and XA capabilities: %v", err)
+	if db.branchType == branch.BranchTypeXA {
+		if err := db.checkDbVersion(ctx, conn); err != nil {
+			log.Errorf("check db version and XA capabilities: %v", err)
+		}
 	}
 }
 
@@ -245,6 +248,7 @@ func (db *DBResource) ConnectionForXA(ctx context.Context, xaXid XAXid) (*XAConn
 func (db *DBResource) checkDbVersion(ctx context.Context, conn driver.Conn) error {
 	switch db.dbType {
 	case types.DBTypeMySQL:
+		db.keepInKeeper = true
 		// Conservatively keep the owner unless both the version and the effective
 		// session variable prove that cross-connection phase two is supported.
 		db.shouldBeHeld = true
@@ -268,6 +272,7 @@ func (db *DBResource) checkDbVersion(ctx context.Context, conn driver.Conn) erro
 			db.shouldBeHeld = !detachOnPrepare
 		}
 	case types.DBTypeMARIADB:
+		db.keepInKeeper = true
 		db.shouldBeHeld = true
 	}
 	return nil

--- a/pkg/datasource/sql/types/const.go
+++ b/pkg/datasource/sql/types/const.go
@@ -357,11 +357,28 @@ func MySQLStrToJavaType(mysqlType string) JDBCType {
 
 // XA transaction related error code constants (based on MySQL/MariaDB specifications)
 const (
+	// ErrCodeXAER_NOTA 1397: XAER_NOTA - Unknown XID.
+	ErrCodeXAER_NOTA = 1397
+
+	// ErrCodeXAER_INVAL 1398: XAER_INVAL - Invalid arguments.
+	ErrCodeXAER_INVAL = 1398
+
 	// ErrCodeXAER_RMFAIL_IDLE 1399: XAER_RMFAIL - The command cannot be executed when global transaction is in the IDLE state
 	// Typically occurs when trying to perform operations on an XA transaction that's in idle state
 	ErrCodeXAER_RMFAIL_IDLE = 1399
 
-	// ErrCodeXAER_INVAL 1400: XAER_INVAL - Invalid XA transaction ID format
-	// Triggered by malformed XID (e.g., invalid gtrid/branchid format or excessive length)
-	ErrCodeXAER_INVAL = 1400
+	// ErrCodeXAER_OUTSIDE 1400: XAER_OUTSIDE - Work is being done outside the global transaction.
+	ErrCodeXAER_OUTSIDE = 1400
+
+	// ErrCodeXAER_RMERR 1401: XAER_RMERR - A resource manager error occurred.
+	ErrCodeXAER_RMERR = 1401
+
+	// ErrCodeXA_RBROLLBACK 1402: The XA branch was rolled back.
+	ErrCodeXA_RBROLLBACK = 1402
+
+	// ErrCodeXA_RBTIMEOUT 1613: The XA branch was rolled back because of a timeout.
+	ErrCodeXA_RBTIMEOUT = 1613
+
+	// ErrCodeXA_RBDEADLOCK 1614: The XA branch was rolled back because of a deadlock.
+	ErrCodeXA_RBDEADLOCK = 1614
 )

--- a/pkg/datasource/sql/types/const_test.go
+++ b/pkg/datasource/sql/types/const_test.go
@@ -190,6 +190,12 @@ func TestMySQLDefCodeConstants(t *testing.T) {
 
 func TestXAErrorCodeConstants(t *testing.T) {
 	// Test XA error code constants
+	assert.Equal(t, 1397, ErrCodeXAER_NOTA)
+	assert.Equal(t, 1398, ErrCodeXAER_INVAL)
 	assert.Equal(t, 1399, ErrCodeXAER_RMFAIL_IDLE)
-	assert.Equal(t, 1400, ErrCodeXAER_INVAL)
+	assert.Equal(t, 1400, ErrCodeXAER_OUTSIDE)
+	assert.Equal(t, 1401, ErrCodeXAER_RMERR)
+	assert.Equal(t, 1402, ErrCodeXA_RBROLLBACK)
+	assert.Equal(t, 1613, ErrCodeXA_RBTIMEOUT)
+	assert.Equal(t, 1614, ErrCodeXA_RBDEADLOCK)
 }

--- a/pkg/datasource/sql/xa/mysql_xa_connection.go
+++ b/pkg/datasource/sql/xa/mysql_xa_connection.go
@@ -79,6 +79,43 @@ func (c *MysqlXAErrorClassifier) IsAlreadyEnded(err error) bool {
 	return false
 }
 
+// IsAlreadyCommitted deliberately returns false because MySQL's XAER_NOTA is
+// ambiguous: the XID may have committed, rolled back, or never existed.
+func (c *MysqlXAErrorClassifier) IsAlreadyCommitted(err error) bool {
+	return false
+}
+
+// IsAlreadyRollbacked reports errors that prove the branch was rolled back.
+func (c *MysqlXAErrorClassifier) IsAlreadyRollbacked(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+
+	switch mysqlErr.Number {
+	case types.ErrCodeXA_RBROLLBACK, types.ErrCodeXA_RBTIMEOUT, types.ErrCodeXA_RBDEADLOCK:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsUnretryable reports deterministic protocol/argument errors. Other RM and
+// connection failures remain retryable.
+func (c *MysqlXAErrorClassifier) IsUnretryable(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+
+	switch mysqlErr.Number {
+	case types.ErrCodeXAER_INVAL, types.ErrCodeXAER_OUTSIDE:
+		return true
+	default:
+		return false
+	}
+}
+
 // MysqlXAConn implements XAResource for MySQL using native XA SQL statements.
 type MysqlXAConn struct {
 	driver.Conn

--- a/pkg/datasource/sql/xa/mysql_xa_connection_test.go
+++ b/pkg/datasource/sql/xa/mysql_xa_connection_test.go
@@ -26,9 +26,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/golang/mock/gomock"
 
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/mock"
+	"seata.apache.org/seata-go/v2/pkg/datasource/sql/types"
 )
 
 func TestMysqlXAConn_Commit(t *testing.T) {
@@ -304,4 +306,44 @@ func (m *mysqlMockRows) Next(dest []driver.Value) error {
 	}
 	m.idx++
 	return nil
+}
+
+func TestMysqlXAErrorClassifier_PhaseTwo(t *testing.T) {
+	classifier := &MysqlXAErrorClassifier{}
+
+	rollbackCodes := []uint16{
+		types.ErrCodeXA_RBROLLBACK,
+		types.ErrCodeXA_RBTIMEOUT,
+		types.ErrCodeXA_RBDEADLOCK,
+	}
+	for _, code := range rollbackCodes {
+		err := &mysql.MySQLError{Number: code}
+		if !classifier.IsAlreadyRollbacked(err) {
+			t.Fatalf("error code %d should prove the XA branch rolled back", code)
+		}
+		if classifier.IsAlreadyCommitted(err) {
+			t.Fatalf("error code %d must not be classified as committed", code)
+		}
+	}
+
+	unretryableCodes := []uint16{
+		types.ErrCodeXAER_INVAL,
+		types.ErrCodeXAER_OUTSIDE,
+	}
+	for _, code := range unretryableCodes {
+		if !classifier.IsUnretryable(&mysql.MySQLError{Number: code}) {
+			t.Fatalf("error code %d should be unretryable", code)
+		}
+	}
+
+	nota := &mysql.MySQLError{Number: types.ErrCodeXAER_NOTA}
+	if classifier.IsAlreadyCommitted(nota) {
+		t.Fatal("XAER_NOTA is ambiguous and must not be classified as committed")
+	}
+	if classifier.IsAlreadyRollbacked(nota) {
+		t.Fatal("XAER_NOTA is ambiguous and must not be classified as rollbacked")
+	}
+	if classifier.IsUnretryable(errors.New("temporary network error")) {
+		t.Fatal("unknown connection errors should remain retryable")
+	}
 }

--- a/pkg/datasource/sql/xa/xa_resource.go
+++ b/pkg/datasource/sql/xa/xa_resource.go
@@ -87,6 +87,16 @@ type XAErrorClassifier interface {
 	IsAlreadyEnded(err error) bool
 }
 
+// XAPhaseTwoErrorClassifier optionally classifies database-specific phase-two
+// outcomes. Implementations must only report an already-completed outcome when
+// the database error proves that exact direction; ambiguous NOTA errors must
+// remain retryable.
+type XAPhaseTwoErrorClassifier interface {
+	IsAlreadyCommitted(err error) bool
+	IsAlreadyRollbacked(err error) bool
+	IsUnretryable(err error) bool
+}
+
 // defaultErrorClassifier is a no-op classifier that never matches any error.
 // Used as a fallback when no database-specific classifier is registered.
 type defaultErrorClassifier struct{}

--- a/pkg/datasource/sql/xa_resource_manager.go
+++ b/pkg/datasource/sql/xa_resource_manager.go
@@ -87,31 +87,36 @@ func (xaManager *XAResourceManager) xaTwoPhaseTimeoutChecker() {
 	for {
 		select {
 		case <-ticker.C:
-			xaManager.resourceCache.Range(func(key, value any) bool {
-				source, ok := value.(*DBResource)
-				if !ok {
-					return true
-				}
-				source.GetKeeper().Range(func(key, value any) bool {
-					connectionXA, isConnectionXA := value.(*XAConn)
-					if !isConnectionXA {
-						return true
-					}
-					if connectionXA.ShouldBeHeld() {
-						return true
-					}
-
-					if time.Now().Sub(connectionXA.prepareTime) > xaManager.config.TwoPhaseHoldTime {
-						if err := connectionXA.CloseForce(); err != nil {
-							log.Errorf("Force close the xa xid:%s physical connection fail", connectionXA.txCtx.XID)
-						}
-					}
-					return true
-				})
-				return true
-			})
+			xaManager.closeTimedOutPhaseTwoConnections(time.Now())
 		}
 	}
+}
+
+func (xaManager *XAResourceManager) closeTimedOutPhaseTwoConnections(now time.Time) {
+	xaManager.resourceCache.Range(func(key, value any) bool {
+		source, ok := value.(*DBResource)
+		if !ok {
+			return true
+		}
+		source.GetKeeper().Range(func(key, value any) bool {
+			connectionXA, isConnectionXA := value.(*XAConn)
+			if !isConnectionXA {
+				return true
+			}
+			prepared, holdUntilPhaseTwo, preparedAt := connectionXA.phaseTwoTimeoutSnapshot()
+			if !prepared || holdUntilPhaseTwo {
+				return true
+			}
+
+			if now.Sub(preparedAt) > xaManager.config.TwoPhaseHoldTime {
+				if err := connectionXA.CloseForce(); err != nil {
+					log.Errorf("Force close the XA physical connection: %v", err)
+				}
+			}
+			return true
+		})
+		return true
+	})
 }
 
 func (xaManager *XAResourceManager) GetBranchType() branch.BranchType {

--- a/pkg/datasource/sql/xa_resource_manager.go
+++ b/pkg/datasource/sql/xa_resource_manager.go
@@ -30,6 +30,7 @@ import (
 
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/datasource"
 	"seata.apache.org/seata-go/v2/pkg/datasource/sql/types"
+	"seata.apache.org/seata-go/v2/pkg/datasource/sql/xa"
 	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 	"seata.apache.org/seata-go/v2/pkg/util/log"
@@ -91,13 +92,12 @@ func (xaManager *XAResourceManager) xaTwoPhaseTimeoutChecker() {
 				if !ok {
 					return true
 				}
-				if source.IsShouldBeHeld() {
-					return true
-				}
-
 				source.GetKeeper().Range(func(key, value any) bool {
 					connectionXA, isConnectionXA := value.(*XAConn)
 					if !isConnectionXA {
+						return true
+					}
+					if connectionXA.ShouldBeHeld() {
 						return true
 					}
 
@@ -138,40 +138,84 @@ func (xaManager *XAResourceManager) xaIDBuilder(xid string, branchId uint64) XAX
 func (xaManager *XAResourceManager) finishBranch(ctx context.Context, xaID XAXid, branchResource rm.BranchResource) (*XAConn, error) {
 	resource, ok := xaManager.resourceCache.Load(branchResource.ResourceId)
 	if !ok {
-		err := fmt.Errorf("unknow resource for rollback xa, resourceId: %s", branchResource.ResourceId)
+		err := fmt.Errorf("unknown resource for XA phase two, resourceId: %s", branchResource.ResourceId)
 		log.Errorf(err.Error())
 		return nil, err
 	}
 
 	dbResource, ok := resource.(*DBResource)
 	if !ok {
-		err := fmt.Errorf("unknow resource for rollback xa, resourceId: %s", branchResource.ResourceId)
+		err := fmt.Errorf("invalid resource for XA phase two, resourceId: %s", branchResource.ResourceId)
 		log.Errorf(err.Error())
 		return nil, err
 	}
 
 	connectionProxyXA, err := dbResource.ConnectionForXA(ctx, xaID)
 	if err != nil {
-		err := fmt.Errorf("get connection for rollback xa, resourceId: %s", branchResource.ResourceId)
-		log.Errorf(err.Error())
-		return nil, err
+		wrappedErr := fmt.Errorf(
+			"get connection for XA phase two, resourceId: %s: %w",
+			branchResource.ResourceId,
+			err,
+		)
+		log.Errorf(wrappedErr.Error())
+		return nil, wrappedErr
 	}
 
 	return connectionProxyXA, nil
 }
 
+func phaseTwoErrorClassifier(connection *XAConn) (xa.XAPhaseTwoErrorClassifier, bool) {
+	classifier, ok := connection.xaErrorClassifier.(xa.XAPhaseTwoErrorClassifier)
+	return classifier, ok
+}
+
 func (xaManager *XAResourceManager) BranchCommit(ctx context.Context, branchResource rm.BranchResource) (branch.BranchStatus, error) {
 	xaID := xaManager.xaIDBuilder(branchResource.Xid, uint64(branchResource.BranchId))
+	if status, err := branchStatus(xaID.String()); err == nil {
+		switch status {
+		case branch.BranchStatusPhasetwoCommitted:
+			return branch.BranchStatusPhasetwoCommitted, nil
+		case branch.BranchStatusPhasetwoRollbacked:
+			return branch.BranchStatusPhasetwoCommitFailedUnretryable, fmt.Errorf(
+				"XA branch %s was already rolled back",
+				xaID.String(),
+			)
+		}
+	}
+
 	connectionProxyXA, err := xaManager.finishBranch(ctx, xaID, branchResource)
 	if err != nil {
-		return branch.BranchStatusPhasetwoRollbackFailedUnretryable, err
+		return branch.BranchStatusPhasetwoCommitFailedRetryable, err
 	}
-	defer connectionProxyXA.Close()
+	wasKept := connectionProxyXA.isKept()
+	if !wasKept {
+		defer connectionProxyXA.Close()
+	}
 
-	if err := connectionProxyXA.XaCommit(ctx, xaID); err != nil {
-		log.Errorf("commit xa, resourceId: %s, err %v", branchResource.ResourceId, err)
+	if err := connectionProxyXA.xaCommit(ctx, xaID, func() {
 		setBranchStatus(xaID.String(), branch.BranchStatusPhasetwoCommitted)
-		return branch.BranchStatusPhasetwoCommitFailedUnretryable, err
+	}); err != nil {
+		log.Errorf("commit xa, resourceId: %s, err %v", branchResource.ResourceId, err)
+		if classifier, ok := phaseTwoErrorClassifier(connectionProxyXA); ok {
+			switch {
+			case classifier.IsAlreadyCommitted(err):
+				connectionProxyXA.completePhaseTwoWith(func() {
+					setBranchStatus(xaID.String(), branch.BranchStatusPhasetwoCommitted)
+				})
+				return branch.BranchStatusPhasetwoCommitted, nil
+			case classifier.IsAlreadyRollbacked(err):
+				connectionProxyXA.completePhaseTwoWith(func() {
+					setBranchStatus(xaID.String(), branch.BranchStatusPhasetwoRollbacked)
+				})
+				return branch.BranchStatusPhasetwoCommitFailedUnretryable, err
+			case classifier.IsUnretryable(err):
+				if closeErr := connectionProxyXA.CloseForce(); closeErr != nil {
+					log.Errorf("close XA connection after unretryable commit failure: %v", closeErr)
+				}
+				return branch.BranchStatusPhasetwoCommitFailedUnretryable, err
+			}
+		}
+		return branch.BranchStatusPhasetwoCommitFailedRetryable, err
 	}
 
 	log.Infof("%s was committed", xaID.String())
@@ -180,16 +224,51 @@ func (xaManager *XAResourceManager) BranchCommit(ctx context.Context, branchReso
 
 func (xaManager *XAResourceManager) BranchRollback(ctx context.Context, branchResource rm.BranchResource) (branch.BranchStatus, error) {
 	xaID := xaManager.xaIDBuilder(branchResource.Xid, uint64(branchResource.BranchId))
+	if status, err := branchStatus(xaID.String()); err == nil {
+		switch status {
+		case branch.BranchStatusPhasetwoRollbacked:
+			return branch.BranchStatusPhasetwoRollbacked, nil
+		case branch.BranchStatusPhasetwoCommitted:
+			return branch.BranchStatusPhasetwoRollbackFailedUnretryable, fmt.Errorf(
+				"XA branch %s was already committed",
+				xaID.String(),
+			)
+		}
+	}
+
 	connectionProxyXA, err := xaManager.finishBranch(ctx, xaID, branchResource)
 	if err != nil {
-		return branch.BranchStatusPhasetwoRollbackFailedUnretryable, err
+		return branch.BranchStatusPhasetwoRollbackFailedRetryable, err
 	}
-	defer connectionProxyXA.Close()
+	wasKept := connectionProxyXA.isKept()
+	if !wasKept {
+		defer connectionProxyXA.Close()
+	}
 
-	if err = connectionProxyXA.XaRollbackByBranchId(ctx, xaID); err != nil {
-		log.Errorf("rollback xa, resourceId: %s, err %v", branchResource.ResourceId, err)
+	if err = connectionProxyXA.xaRollback(ctx, xaID, func() {
 		setBranchStatus(xaID.String(), branch.BranchStatusPhasetwoRollbacked)
-		return branch.BranchStatusPhasetwoRollbackFailedUnretryable, err
+	}); err != nil {
+		log.Errorf("rollback xa, resourceId: %s, err %v", branchResource.ResourceId, err)
+		if classifier, ok := phaseTwoErrorClassifier(connectionProxyXA); ok {
+			switch {
+			case classifier.IsAlreadyRollbacked(err):
+				connectionProxyXA.completePhaseTwoWith(func() {
+					setBranchStatus(xaID.String(), branch.BranchStatusPhasetwoRollbacked)
+				})
+				return branch.BranchStatusPhasetwoRollbacked, nil
+			case classifier.IsAlreadyCommitted(err):
+				connectionProxyXA.completePhaseTwoWith(func() {
+					setBranchStatus(xaID.String(), branch.BranchStatusPhasetwoCommitted)
+				})
+				return branch.BranchStatusPhasetwoRollbackFailedUnretryable, err
+			case classifier.IsUnretryable(err):
+				if closeErr := connectionProxyXA.CloseForce(); closeErr != nil {
+					log.Errorf("close XA connection after unretryable rollback failure: %v", closeErr)
+				}
+				return branch.BranchStatusPhasetwoRollbackFailedUnretryable, err
+			}
+		}
+		return branch.BranchStatusPhasetwoRollbackFailedRetryable, err
 	}
 
 	log.Infof("%s was rollback", xaID.String())

--- a/pkg/datasource/sql/xa_resource_manager_test.go
+++ b/pkg/datasource/sql/xa_resource_manager_test.go
@@ -19,19 +19,175 @@ package sql
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/bluele/gcache"
 	"github.com/stretchr/testify/assert"
 
+	"seata.apache.org/seata-go/v2/pkg/datasource/sql/types"
+	"seata.apache.org/seata-go/v2/pkg/datasource/sql/xa"
 	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/protocol/message"
 	"seata.apache.org/seata-go/v2/pkg/remoting/getty"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 	gettyrm "seata.apache.org/seata-go/v2/pkg/rm/remoting/getty"
 )
+
+type phaseTwoTestDriverConn struct{}
+
+func (c *phaseTwoTestDriverConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (c *phaseTwoTestDriverConn) Close() error {
+	return nil
+}
+
+func (c *phaseTwoTestDriverConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not supported")
+}
+
+type phaseTwoTestXAResource struct {
+	commitErr         error
+	rollbackErr       error
+	alreadyCommitted  bool
+	alreadyRollbacked bool
+	unretryable       bool
+	commitCalls       int
+	rollbackCalls     int
+}
+
+func (r *phaseTwoTestXAResource) Commit(ctx context.Context, xid string, onePhase bool) error {
+	r.commitCalls++
+	return r.commitErr
+}
+
+func (r *phaseTwoTestXAResource) End(ctx context.Context, xid string, flags int) error {
+	return nil
+}
+
+func (r *phaseTwoTestXAResource) Forget(ctx context.Context, xid string) error {
+	return nil
+}
+
+func (r *phaseTwoTestXAResource) GetTransactionTimeout() time.Duration {
+	return 0
+}
+
+func (r *phaseTwoTestXAResource) IsSameRM(ctx context.Context, resource xa.XAResource) bool {
+	return false
+}
+
+func (r *phaseTwoTestXAResource) XAPrepare(ctx context.Context, xid string) error {
+	return nil
+}
+
+func (r *phaseTwoTestXAResource) Recover(ctx context.Context, flag int) ([]string, error) {
+	return nil, nil
+}
+
+func (r *phaseTwoTestXAResource) Rollback(ctx context.Context, xid string) error {
+	r.rollbackCalls++
+	return r.rollbackErr
+}
+
+func (r *phaseTwoTestXAResource) SetTransactionTimeout(duration time.Duration) bool {
+	return false
+}
+
+func (r *phaseTwoTestXAResource) Start(ctx context.Context, xid string, flags int) error {
+	return nil
+}
+
+func (r *phaseTwoTestXAResource) IsAlreadyEnded(err error) bool {
+	return false
+}
+
+func (r *phaseTwoTestXAResource) IsAlreadyCommitted(err error) bool {
+	return r.alreadyCommitted
+}
+
+func (r *phaseTwoTestXAResource) IsAlreadyRollbacked(err error) bool {
+	return r.alreadyRollbacked
+}
+
+func (r *phaseTwoTestXAResource) IsUnretryable(err error) bool {
+	return r.unretryable
+}
+
+func newPhaseTwoTestManager(
+	t *testing.T,
+	resource *phaseTwoTestXAResource,
+) (*XAResourceManager, rm.BranchResource, string) {
+	t.Helper()
+
+	branchStatusCache = gcache.New(16).LRU().Expiration(time.Minute).Build()
+
+	const (
+		resourceID = "mysql://127.0.0.1/test"
+		globalXID  = "127.0.0.1:8091:1001"
+		branchID   = int64(2001)
+	)
+
+	dbResource := &DBResource{
+		resourceID:   resourceID,
+		dbType:       types.DBTypeMySQL,
+		shouldBeHeld: true,
+	}
+	xaID := XaIdBuild(globalXID, uint64(branchID))
+	xaConn := &XAConn{
+		Conn: &Conn{
+			targetConn: &phaseTwoTestDriverConn{},
+			res:        dbResource,
+			dbType:     types.DBTypeMySQL,
+		},
+		xaResource:        resource,
+		xaErrorClassifier: resource,
+		xaBranchXid:       xaID,
+		shouldBeHeld:      true,
+		isConnKept:        true,
+		prepareTime:       time.Now(),
+		xaActive:          false,
+		rollBacked:        false,
+	}
+	assert.NoError(t, dbResource.Hold(xaID.String(), xaConn))
+
+	manager := &XAResourceManager{}
+	manager.resourceCache.Store(resourceID, dbResource)
+
+	return manager, rm.BranchResource{
+		BranchType: branch.BranchTypeXA,
+		Xid:        globalXID,
+		BranchId:   branchID,
+		ResourceId: resourceID,
+	}, xaID.String()
+}
+
+func assertPhaseTwoConnectionHeld(
+	t *testing.T,
+	manager *XAResourceManager,
+	resource rm.BranchResource,
+	xaID string,
+	want bool,
+) {
+	t.Helper()
+
+	value, ok := manager.resourceCache.Load(resource.ResourceId)
+	if !assert.True(t, ok) {
+		return
+	}
+	dbResource, ok := value.(*DBResource)
+	if !assert.True(t, ok) {
+		return
+	}
+	_, held := dbResource.Lookup(xaID)
+	assert.Equal(t, want, held)
+}
 
 func TestXAResourceManager_LockQuery(t *testing.T) {
 	tests := []struct {
@@ -93,4 +249,201 @@ func TestXAResourceManager_LockQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestXAResourceManager_BranchCommit_StatusAndCache(t *testing.T) {
+	t.Run("success caches committed terminal status", func(t *testing.T) {
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{})
+
+		status, err := manager.BranchCommit(context.Background(), resource)
+
+		assert.NoError(t, err)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, false)
+	})
+
+	t.Run("failure stays retryable and does not cache success", func(t *testing.T) {
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{
+			commitErr: errors.New("temporary commit failure"),
+		})
+
+		status, err := manager.BranchCommit(context.Background(), resource)
+
+		assert.EqualError(t, err, "temporary commit failure")
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitFailedRetryable, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusUnknown, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, true)
+	})
+}
+
+func TestXAResourceManager_BranchRollback_StatusAndCache(t *testing.T) {
+	t.Run("success caches rollbacked terminal status", func(t *testing.T) {
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{})
+
+		status, err := manager.BranchRollback(context.Background(), resource)
+
+		assert.NoError(t, err)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbacked, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbacked, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, false)
+	})
+
+	t.Run("failure stays retryable and does not cache success", func(t *testing.T) {
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{
+			rollbackErr: errors.New("temporary rollback failure"),
+		})
+
+		status, err := manager.BranchRollback(context.Background(), resource)
+
+		assert.EqualError(t, err, "temporary rollback failure")
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbackFailedRetryable, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusUnknown, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, true)
+	})
+}
+
+func TestXAResourceManager_BranchCommit_ClassifiesTerminalErrors(t *testing.T) {
+	t.Run("already committed converges successfully", func(t *testing.T) {
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{
+			commitErr:        errors.New("already committed"),
+			alreadyCommitted: true,
+		})
+
+		status, err := manager.BranchCommit(context.Background(), resource)
+
+		assert.NoError(t, err)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, false)
+	})
+
+	t.Run("already rollbacked is an unretryable commit failure", func(t *testing.T) {
+		commitErr := errors.New("branch already rollbacked")
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{
+			commitErr:         commitErr,
+			alreadyRollbacked: true,
+		})
+
+		status, err := manager.BranchCommit(context.Background(), resource)
+
+		assert.ErrorIs(t, err, commitErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitFailedUnretryable, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbacked, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, false)
+	})
+
+	t.Run("protocol error is unretryable without inventing a terminal outcome", func(t *testing.T) {
+		commitErr := errors.New("invalid XA arguments")
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{
+			commitErr:   commitErr,
+			unretryable: true,
+		})
+
+		status, err := manager.BranchCommit(context.Background(), resource)
+
+		assert.ErrorIs(t, err, commitErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitFailedUnretryable, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusUnknown, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, false)
+	})
+}
+
+func TestXAResourceManager_BranchRollback_ClassifiesTerminalErrors(t *testing.T) {
+	t.Run("already rollbacked converges successfully", func(t *testing.T) {
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{
+			rollbackErr:       errors.New("already rollbacked"),
+			alreadyRollbacked: true,
+		})
+
+		status, err := manager.BranchRollback(context.Background(), resource)
+
+		assert.NoError(t, err)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbacked, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbacked, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, false)
+	})
+
+	t.Run("already committed is an unretryable rollback failure", func(t *testing.T) {
+		rollbackErr := errors.New("branch already committed")
+		manager, resource, xaID := newPhaseTwoTestManager(t, &phaseTwoTestXAResource{
+			rollbackErr:      rollbackErr,
+			alreadyCommitted: true,
+		})
+
+		status, err := manager.BranchRollback(context.Background(), resource)
+
+		assert.ErrorIs(t, err, rollbackErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbackFailedUnretryable, status)
+		cached, cacheErr := branchStatus(xaID)
+		assert.NoError(t, cacheErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, cached)
+		assertPhaseTwoConnectionHeld(t, manager, resource, xaID, false)
+	})
+}
+
+func TestXAResourceManager_CachedTerminalStatusMakesPhaseTwoIdempotent(t *testing.T) {
+	t.Run("repeated commit does not hit the database", func(t *testing.T) {
+		xaResource := &phaseTwoTestXAResource{}
+		manager, resource, _ := newPhaseTwoTestManager(t, xaResource)
+
+		firstStatus, firstErr := manager.BranchCommit(context.Background(), resource)
+		assert.NoError(t, firstErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, firstStatus)
+
+		xaResource.commitErr = errors.New("database should not be called again")
+		secondStatus, secondErr := manager.BranchCommit(context.Background(), resource)
+		assert.NoError(t, secondErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, secondStatus)
+		assert.Equal(t, 1, xaResource.commitCalls)
+	})
+
+	t.Run("opposite retry returns an unretryable conflict", func(t *testing.T) {
+		xaResource := &phaseTwoTestXAResource{}
+		manager, resource, _ := newPhaseTwoTestManager(t, xaResource)
+
+		commitStatus, commitErr := manager.BranchCommit(context.Background(), resource)
+		assert.NoError(t, commitErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoCommitted, commitStatus)
+
+		rollbackStatus, rollbackErr := manager.BranchRollback(context.Background(), resource)
+		assert.Error(t, rollbackErr)
+		assert.EqualValues(t, branch.BranchStatusPhasetwoRollbackFailedUnretryable, rollbackStatus)
+		assert.Equal(t, 0, xaResource.rollbackCalls)
+	})
+}
+
+func TestXAResourceManager_FinishBranchErrorUsesCorrectDirection(t *testing.T) {
+	branchStatusCache = gcache.New(16).LRU().Expiration(time.Minute).Build()
+	manager := &XAResourceManager{}
+	resource := rm.BranchResource{
+		BranchType: branch.BranchTypeXA,
+		Xid:        "127.0.0.1:8091:1001",
+		BranchId:   2001,
+		ResourceId: "missing-resource",
+	}
+
+	commitStatus, commitErr := manager.BranchCommit(context.Background(), resource)
+	assert.Error(t, commitErr)
+	assert.EqualValues(t, branch.BranchStatusPhasetwoCommitFailedRetryable, commitStatus)
+
+	rollbackStatus, rollbackErr := manager.BranchRollback(context.Background(), resource)
+	assert.Error(t, rollbackErr)
+	assert.EqualValues(t, branch.BranchStatusPhasetwoRollbackFailedRetryable, rollbackStatus)
 }

--- a/pkg/datasource/sql/xa_resource_manager_test.go
+++ b/pkg/datasource/sql/xa_resource_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -246,6 +247,82 @@ func TestXAResourceManager_LockQuery(t *testing.T) {
 				assert.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestXAResourceManager_CloseTimedOutPhaseTwoConnections(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name              string
+		prepared          bool
+		holdUntilPhaseTwo bool
+		preparedAt        time.Time
+		wantClosed        bool
+	}{
+		{
+			name:       "unprepared keeper entry is ignored",
+			preparedAt: time.Time{},
+		},
+		{
+			name:              "mandatory owner is retained",
+			prepared:          true,
+			holdUntilPhaseTwo: true,
+			preparedAt:        now.Add(-time.Minute),
+		},
+		{
+			name:       "recent detachable branch is retained",
+			prepared:   true,
+			preparedAt: now.Add(-500 * time.Millisecond),
+		},
+		{
+			name:       "expired detachable branch is force closed",
+			prepared:   true,
+			preparedAt: now.Add(-2 * time.Second),
+			wantClosed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			underlying := &closeErrorDriverConn{}
+			xaID := XaIdBuild("127.0.0.1:8091:1001", 123)
+			resource := &DBResource{
+				resourceID:   "mysql://127.0.0.1/test",
+				dbType:       types.DBTypeMySQL,
+				keepInKeeper: true,
+			}
+			xaConn := &XAConn{
+				Conn: &Conn{
+					targetConn: underlying,
+					res:        resource,
+					dbType:     types.DBTypeMySQL,
+				},
+				xaBranchXid:         xaID,
+				keepInKeeper:        true,
+				shouldBeHeld:        tt.holdUntilPhaseTwo,
+				isConnKept:          true,
+				preparedForPhaseTwo: tt.prepared,
+				prepareTime:         tt.preparedAt,
+			}
+			assert.NoError(t, resource.Hold(xaID.String(), xaConn))
+
+			manager := &XAResourceManager{
+				config: XAConfig{TwoPhaseHoldTime: time.Second},
+			}
+			manager.resourceCache.Store(resource.resourceID, resource)
+
+			manager.closeTimedOutPhaseTwoConnections(now)
+
+			if tt.wantClosed {
+				assert.Equal(t, int32(1), atomic.LoadInt32(&underlying.closeCalls))
+				_, held := resource.Lookup(xaID.String())
+				assert.False(t, held)
+			} else {
+				assert.Equal(t, int32(0), atomic.LoadInt32(&underlying.closeCalls))
+				_, held := resource.Lookup(xaID.String())
+				assert.True(t, held)
 			}
 		})
 	}


### PR DESCRIPTION
- [x] I have registered the PR [changes](https://github.com/apache/incubator-seata-go/tree/master/changes).

**What this PR does**:

This PR fixes XA failure-path correctness, retry semantics, idempotency, and physical connection ownership.

## Problem and Root Cause

### 1. Incorrect phase-two status and terminal cache

When XA phase two fails, the current implementation can return or record an incorrect terminal result:

- `BranchCommit` returns a rollback-failure status when resource or connection acquisition fails.
- Commit failure writes `PhasetwoCommitted` to `branchStatusCache`.
- Rollback failure writes `PhasetwoRollbacked` to the cache.
- Temporary database and connection failures are returned as unretryable.
- A repeated callback does not consume the cached terminal state and accesses the database again.

The root cause is that phase-two error handling does not distinguish commit and rollback directions, retryable and unretryable errors, confirmed terminal outcomes and ambiguous errors, or first execution and repeated callbacks. The cache is also updated from failure branches instead of only after a confirmed terminal result.

### 2. Phase-one errors can be lost

When `XA END` or `XA PREPARE` fails, `commitErrorHandle` performs a compensating rollback. If that rollback succeeds, the previous implementation returns `nil`, because the local error variable only receives the rollback result. The original END/PREPARE error is therefore lost, and the caller can subsequently treat phase one as successful.

### 3. Retryable failures lose their owner connection

`XAConn.XaCommit` and `XAConn.XaRollback` release the keeper entry regardless of the database result. For databases or configurations that still require the original physical connection, a temporary error therefore removes the only usable owner before the TC retries.

The root cause is that database execution and connection ownership completion are handled independently. The code does not model whether phase two actually reached a terminal state.

### 4. Held connections can still be reused by `database/sql`

Keeping an `XAConn` in `DBResource.keeper` does not automatically remove its physical connection from the `database/sql` pool. `ResetSession` previously returned `nil`, so the pool could reuse a prepared connection while the same `XAConn` was still referenced by the keeper.

At the same time, pool discard, phase-two completion, and timeout close could operate on the same physical connection without a shared ownership guard. This can cause prepared connection reuse, overwritten branch state, phase-two/timeout races, duplicate closes, and keeper entries pointing to unusable connections.

### 5. Forced close can leak keeper state

`XAConn.CloseForce` returns immediately when the underlying physical close returns an error. As a result, the keeper entry and local branch state are not cleaned up.

### 6. Cached terminal states are ignored

`XAConn.termination` reads `branchStatusCache`, but only checks whether the cache lookup itself returned an error. A successfully retrieved `PhasetwoCommitted` or `PhasetwoRollbacked` value is ignored.

### 7. MySQL detach capability is determined incompletely

MySQL 8.0.29 introduced cross-connection phase two, but it also depends on the effective session variable `@@session.xa_detach_on_prepare`. The previous implementation only checked the server version. Because this is a session variable, checking it once on an initialization connection is also insufficient: the actual XA physical connection may have a different value.

### 8. The existing error classifier is not sufficient for phase two

`XAErrorClassifier.IsAlreadyEnded` only helps the XA END path. It cannot distinguish already committed, already rollbacked, deterministic protocol errors, ambiguous `XAER_NOTA`, or temporary connection and RM failures.

## Solution

### 1. Make terminal-state publication directional and idempotent

Phase-two handling now:

- returns commit-failure status for commit-path failures;
- returns rollback-failure status for rollback-path failures;
- treats unknown connection and RM errors as retryable;
- writes terminal cache entries only after confirmed success;
- checks the terminal cache before accessing the database;
- returns cached same-direction outcomes as idempotent success;
- returns cached opposite-direction outcomes as unretryable conflicts.

The terminal cache is published before releasing the keeper, so a concurrent retry cannot observe neither the owner nor the terminal result.

### 2. Preserve the original phase-one error

`commitErrorHandle` now receives the original failure explicitly. If compensating rollback succeeds, the original END/PREPARE error is returned. If rollback also fails, both errors are retained with `errors.Join`.

### 3. Release keeper ownership only after confirmed completion

`XaCommit` and `XaRollback` release the keeper only when the database operation succeeds or the database-specific classifier proves the exact same terminal direction. Retryable errors keep the owner connection available for TC retry. Opposite terminal outcomes are recorded with their actual status and returned as unretryable conflicts.

### 4. Transfer pending connections out of the pool safely

Held XA connections now have explicit synchronized ownership state:

- `ResetSession` returns `driver.ErrBadConn` for a pending keeper-owned branch;
- `database/sql` discards the wrapper instead of reusing it;
- `XAConn.Close` does not close the physical connection while keeper owns it;
- phase two or timeout cleanup becomes the physical owner;
- a mutex serializes pool discard, phase two, and forced close;
- a `physicalClosed` guard prevents duplicate closes.

If phase two finishes before pool discard, the connection can remain reusable. If the pool already discarded it, phase-two completion closes it exactly once.

### 5. Always clean up after forced close

`CloseForce` now performs keeper and branch-state cleanup regardless of the physical close result. The original close error is still returned.

### 6. Handle cached terminal states explicitly

`termination` now rejects branches cached as `PhasetwoCommitted` or `PhasetwoRollbacked` and releases any remaining keeper ownership.

### 7. Probe MySQL detach capability on the actual XA connection

For MySQL 8.0.29 and later:

1. The initialization probe marks the resource as requiring per-connection capability detection.
2. Every actual XA physical connection reads `@@session.xa_detach_on_prepare`.
3. When enabled, phase two may use a new connection.
4. When disabled, the original physical connection is retained.
5. If the probe fails, the implementation conservatively retains the owner.

### 8. Add optional phase-two error classification

This PR introduces the optional `XAPhaseTwoErrorClassifier`:

```go
type XAPhaseTwoErrorClassifier interface {
    IsAlreadyCommitted(err error) bool
    IsAlreadyRollbacked(err error) bool
    IsUnretryable(err error) bool
}
```

The MySQL implementation keeps `XAER_NOTA` ambiguous and retryable, recognizes XA rollback terminal codes, treats `XAER_INVAL` and `XAER_OUTSIDE` as unretryable, and leaves unknown RM and connection failures retryable.

## Implementation Details

### `pkg/datasource/sql/xa_resource_manager.go`

- Correct commit/rollback failure direction.
- Consume cached terminal status before database access.
- Publish terminal status before releasing keeper ownership.
- Handle same-direction retries as idempotent success.
- Handle opposite terminal states as unretryable conflicts.
- Apply database-specific phase-two classification.
- Force cleanup for deterministic unretryable errors.
- Preserve wrapped connection acquisition errors.

### `pkg/datasource/sql/conn_xa.go`

- Preserve END/PREPARE errors through `commitErrorHandle`.
- Use `errors.Join` when compensating rollback also fails.
- Retain keeper entries on retryable phase-two errors.
- Add synchronized keeper and physical connection ownership.
- Return `driver.ErrBadConn` for pool reuse of held branches.
- Prevent duplicate physical closes.
- Serialize phase two and timeout cleanup.
- Release keeper on XA START failure.
- Always clean keeper state in `CloseForce`.
- Handle cached terminal states in `termination`.

### `pkg/datasource/sql/db.go`

- Keep MySQL owner connections conservatively by default.
- Detect MySQL 8.0.29+ detach capability.
- Mark applicable resources for per-connection session probing.
- Parse `xa_detach_on_prepare` from driver-native result types.
- Fall back to owner retention on probe failure.

### `pkg/datasource/sql/xa/xa_resource.go`

- Add the optional `XAPhaseTwoErrorClassifier`.
- Keep the existing `XAResource` and `XAResourceFactory` contracts unchanged.

### `pkg/datasource/sql/xa/mysql_xa_connection.go`

- Implement MySQL phase-two terminal and protocol-error classification.
- Keep `XAER_NOTA` unclassified because it does not prove a terminal direction.

### `pkg/datasource/sql/types/const.go`

Correct and extend MySQL/MariaDB XA error constants for `XAER_NOTA`, `XAER_INVAL`, `XAER_RMFAIL`, `XAER_OUTSIDE`, `XAER_RMERR`, `XA_RBROLLBACK`, `XA_RBTIMEOUT`, and `XA_RBDEADLOCK`.

### Regression Tests

Added coverage for:

- correct commit/rollback status direction;
- terminal cache publication;
- repeated same-direction callbacks;
- opposite-direction callbacks;
- retryable and unretryable errors;
- confirmed committed/rollbacked outcomes;
- original Prepare error preservation;
- forced-close cleanup;
- XA START cleanup;
- pool-to-keeper ownership transfer;
- phase-two/timeout close concurrency;
- single physical close ownership;
- MySQL version and detach combinations;
- per-session detach changes;
- conservative fallback on capability probe failure;
- MySQL phase-two error classification.

**Which issue(s) this PR fixes**:

Fixes #1147

**Special notes for your reviewer**:

- `branchStatusCache` remains a process-local idempotency optimization and is not used as durable recovery storage.
- `XAER_NOTA` remains retryable because it cannot prove whether a branch committed, rolled back, or never existed.
- The existing `XAResource` interface is unchanged.
- Connection retention is conservative whenever detach capability cannot be proven.
- Most added lines are regression and concurrency tests for previously uncovered failure paths.

## Test Plan

```bash
go test ./pkg/datasource/sql/...
# 1773 passed in 23 packages

go test -race ./pkg/datasource/sql \
  -run 'TestXA(ResourceManager|Conn)_|TestDBResource_CheckDBVersion|TestExecBatch(Context|InTxContext)' \
  -count=1
# 83 passed in 1 package

go test ./pkg/datasource/sql/xa ./pkg/datasource/sql/types -count=1
# 590 passed in 2 packages

go vet ./pkg/datasource/sql/...
git diff --check
```

On Go 1.26.5 / macOS arm64, the repository-wide test command reaches an unrelated pre-existing SIGBUS in a gomonkey-based gRPC test. The modified SQL datasource packages and focused race suites pass.

**Does this PR introduce a user-facing change?**:

```release-note
Fix XA failure handling so retryable phase-two operations preserve their connection ownership, repeated callbacks remain idempotent, and failed branches are no longer reported or cached as successful.
```