### PR TITLE
fix: correct XA connection hold fallback

### DIFF
--- a/pkg/datasource/sql/conn_xa.go
+++ b/pkg/datasource/sql/conn_xa.go
@@ -578,7 +578,7 @@ func (c *XAConn) commitErrorHandle(ctx context.Context) error {
 }
 
 func (c *XAConn) ShouldBeHeld() bool {
-	return c.res.IsShouldBeHeld() || (c.res.GetDbType().String() != "" && c.res.GetDbType() != types.DBTypeUnknown)
+	return c.res.IsShouldBeHeld() || c.res.GetDbType() == types.DBTypeUnknown
 }
 
 func (c *XAConn) checkTimeout(ctx context.Context, now time.Time) error {

--- a/pkg/datasource/sql/conn_xa_test.go
+++ b/pkg/datasource/sql/conn_xa_test.go
@@ -261,6 +261,46 @@ func newMockXAConn(t *testing.T, ctrl *gomock.Controller, branchID int64) (*XACo
 	}, mockMgr
 }
 
+func TestXAConn_ShouldBeHeld(t *testing.T) {
+	tests := []struct {
+		name         string
+		dbType       types.DBType
+		resourceHold bool
+		want         bool
+	}{
+		{
+			name:         "resource requires owner connection",
+			dbType:       types.DBTypeMySQL,
+			resourceHold: true,
+			want:         true,
+		},
+		{
+			name:         "known database supports detached phase two",
+			dbType:       types.DBTypePostgreSQL,
+			resourceHold: false,
+			want:         false,
+		},
+		{
+			name:         "unknown database falls back to retaining connection",
+			dbType:       types.DBTypeUnknown,
+			resourceHold: false,
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &DBResource{
+				dbType:       tt.dbType,
+				shouldBeHeld: tt.resourceHold,
+			}
+			conn := &XAConn{Conn: &Conn{res: resource}}
+
+			assert.Equal(t, tt.want, conn.ShouldBeHeld())
+		})
+	}
+}
+
 func TestXAConn_ExecContext(t *testing.T) {
 
 	ctrl, db, mi, ti := initXAConnTestResource(t)


### PR DESCRIPTION
- [ ] I have registered the PR changes.

**What this PR does**:

`XAConn.ShouldBeHeld` currently treats every known `DBType` as hold-required because `DBType.String()` never returns an empty string.

This focused change aligns the fallback with Seata Java:

- retain the connection when the resource capability requires it;
- retain conservatively when `DBType` is unknown;
- do not override a known database whose capability says detached phase two is supported.

It also adds table-driven regression tests for the three combinations.

Seata Java reference:
https://github.com/apache/seata/pull/4765

**Which issue(s) this PR fixes**:

Fixes #1149

**Special notes for your reviewer**:

#1147/#1148 contain a broader XA lifecycle and connection-ownership redesign. This PR intentionally limits itself to the reversed fallback predicate and regression tests.

For MySQL 8.0.29+, version alone is not a complete detached-phase-two capability check because `@@session.xa_detach_on_prepare` also matters. This PR does not claim to solve that separate probing gap.

**Test Plan**:

```bash
go test ./pkg/datasource/sql/... -count=1
go test -race ./pkg/datasource/sql -run '^TestXAConn_ShouldBeHeld$' -count=1
```

**Does this PR introduce a user-facing change?**:

```release-note
Fix XA connection retention fallback so known databases are not always treated as requiring the original connection.
```