### PR TITLE
fix(rm): send branch failure response when branch operation fails

### DIFF
--- a/changes/dev.md
+++ b/changes/dev.md
@@ -32,6 +32,7 @@
 
 ### bugfix：
 
+  - [[#1156](https://github.com/apache/incubator-seata-go/issues/1156)] send RM branch failure responses to TC and align their message encoding with the Java wire format
   - [[#904](https://github.com/apache/incubator-seata-go/issues/904)] fix "busy buffer" / "driver: bad connection" when a `SELECT ... FOR UPDATE` is followed by another statement under XA autoCommit, by deferring the branch commit (XA END + XA PREPARE) until the query rows are closed
   - [[#130](https://github.com/apache/incubator-seata-go/pull/130)] getty session auto close bug
   - [[#991](https://github.com/apache/incubator-seata-go/issues/991)] fix connection leaks and prevent nil pointer panic in async worker

--- a/pkg/protocol/codec/branch_commit_response_codec.go
+++ b/pkg/protocol/codec/branch_commit_response_codec.go
@@ -35,7 +35,7 @@ func (g *BranchCommitResponseCodec) Decode(in []byte) interface{} {
 
 	data.ResultCode = message.ResultCode(bytes.ReadByte(buf))
 	if data.ResultCode == message.ResultCodeFailed {
-		data.Msg = bytes.ReadString8Length(buf)
+		data.Msg = bytes.ReadString16Length(buf)
 	}
 	data.TransactionErrorCode = serror.TransactionErrorCode(bytes.ReadByte(buf))
 	data.Xid = bytes.ReadString16Length(buf)
@@ -52,10 +52,10 @@ func (g *BranchCommitResponseCodec) Encode(in interface{}) []byte {
 	buf.WriteByte(byte(data.ResultCode))
 	if data.ResultCode == message.ResultCodeFailed {
 		msg := data.Msg
-		if len(data.Msg) > math.MaxInt8 {
-			msg = data.Msg[:math.MaxInt8]
+		if len(data.Msg) > math.MaxInt16 {
+			msg = data.Msg[:math.MaxInt16]
 		}
-		bytes.WriteString8Length(msg, buf)
+		bytes.WriteString16Length(msg, buf)
 	}
 	buf.WriteByte(byte(data.TransactionErrorCode))
 	bytes.WriteString16Length(data.Xid, buf)

--- a/pkg/protocol/codec/branch_commit_response_codec_test.go
+++ b/pkg/protocol/codec/branch_commit_response_codec_test.go
@@ -49,3 +49,36 @@ func TestBranchCommitResponseCodec(t *testing.T) {
 
 	assert.Equal(t, msg, msg2)
 }
+
+// Byte vector derived from Java AbstractResultMessageCodec,
+// AbstractTransactionResponseCodec, and AbstractBranchEndResponseCodec.
+func TestBranchCommitResponseCodec_JavaWireFormat(t *testing.T) {
+	msg := message.BranchCommitResponse{
+		AbstractBranchEndResponse: message.AbstractBranchEndResponse{
+			Xid:          "192.168.0.1:8091:1234",
+			BranchId:     5678,
+			BranchStatus: model2.BranchStatusPhasetwoCommitFailedRetryable,
+			AbstractTransactionResponse: message.AbstractTransactionResponse{
+				TransactionErrorCode: serror.TransactionErrorCodeUnknown,
+				AbstractResultMessage: message.AbstractResultMessage{
+					ResultCode: message.ResultCodeFailed,
+					Msg:        "storage failed",
+				},
+			},
+		},
+	}
+	want := []byte{
+		0x00,
+		0x00, 0x0e,
+		's', 't', 'o', 'r', 'a', 'g', 'e', ' ', 'f', 'a', 'i', 'l', 'e', 'd',
+		0x00,
+		0x00, 0x15,
+		'1', '9', '2', '.', '1', '6', '8', '.', '0', '.', '1', ':', '8', '0', '9', '1', ':', '1', '2', '3', '4',
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x2e,
+		0x06,
+	}
+
+	codec := BranchCommitResponseCodec{}
+	assert.Equal(t, want, codec.Encode(msg), "encode must reproduce the Java bytes exactly")
+	assert.Equal(t, msg, codec.Decode(want))
+}

--- a/pkg/protocol/codec/branch_commit_response_codec_test.go
+++ b/pkg/protocol/codec/branch_commit_response_codec_test.go
@@ -18,6 +18,8 @@
 package codec
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +50,33 @@ func TestBranchCommitResponseCodec(t *testing.T) {
 	msg2 := codec.Decode(bytes)
 
 	assert.Equal(t, msg, msg2)
+}
+
+func TestBranchCommitResponseCodec_TruncatesLongMessageWithoutShiftingFields(t *testing.T) {
+	msg := message.BranchCommitResponse{
+		AbstractBranchEndResponse: message.AbstractBranchEndResponse{
+			Xid:          "xid",
+			BranchId:     123,
+			BranchStatus: model2.BranchStatusPhasetwoCommitFailedRetryable,
+			AbstractTransactionResponse: message.AbstractTransactionResponse{
+				TransactionErrorCode: serror.TransactionErrorCodeFailedToSendBranchCommitRequest,
+				AbstractResultMessage: message.AbstractResultMessage{
+					ResultCode: message.ResultCodeFailed,
+					Msg:        strings.Repeat("x", math.MaxInt16+100),
+				},
+			},
+		},
+	}
+
+	codec := BranchCommitResponseCodec{}
+	decoded := codec.Decode(codec.Encode(msg)).(message.BranchCommitResponse)
+
+	assert.Equal(t, message.ResultCodeFailed, decoded.ResultCode)
+	assert.Equal(t, strings.Repeat("x", math.MaxInt16), decoded.Msg)
+	assert.Equal(t, msg.TransactionErrorCode, decoded.TransactionErrorCode)
+	assert.Equal(t, msg.Xid, decoded.Xid)
+	assert.Equal(t, msg.BranchId, decoded.BranchId)
+	assert.Equal(t, msg.BranchStatus, decoded.BranchStatus)
 }
 
 // Byte vector derived from Java AbstractResultMessageCodec,

--- a/pkg/protocol/codec/branch_rollback_response_codec.go
+++ b/pkg/protocol/codec/branch_rollback_response_codec.go
@@ -51,8 +51,8 @@ func (g *BranchRollbackResponseCodec) Encode(in interface{}) []byte {
 	buf.WriteByte(byte(data.ResultCode))
 	if data.ResultCode == message.ResultCodeFailed {
 		msg := data.Msg
-		if len(data.Msg) > math.MaxInt16 {
-			msg = data.Msg[:math.MaxInt16]
+		if len(data.Msg) > math.MaxInt8 {
+			msg = data.Msg[:math.MaxInt8]
 		}
 		bytes.WriteString8Length(msg, buf)
 	}

--- a/pkg/protocol/codec/branch_rollback_response_codec.go
+++ b/pkg/protocol/codec/branch_rollback_response_codec.go
@@ -34,7 +34,7 @@ func (g *BranchRollbackResponseCodec) Decode(in []byte) interface{} {
 
 	data.ResultCode = message.ResultCode(bytes.ReadByte(buf))
 	if data.ResultCode == message.ResultCodeFailed {
-		data.Msg = bytes.ReadString8Length(buf)
+		data.Msg = bytes.ReadString16Length(buf)
 	}
 	data.TransactionErrorCode = serror.TransactionErrorCode(bytes.ReadByte(buf))
 	data.Xid = bytes.ReadString16Length(buf)
@@ -51,10 +51,10 @@ func (g *BranchRollbackResponseCodec) Encode(in interface{}) []byte {
 	buf.WriteByte(byte(data.ResultCode))
 	if data.ResultCode == message.ResultCodeFailed {
 		msg := data.Msg
-		if len(data.Msg) > math.MaxInt8 {
-			msg = data.Msg[:math.MaxInt8]
+		if len(data.Msg) > math.MaxInt16 {
+			msg = data.Msg[:math.MaxInt16]
 		}
-		bytes.WriteString8Length(msg, buf)
+		bytes.WriteString16Length(msg, buf)
 	}
 	buf.WriteByte(byte(data.TransactionErrorCode))
 	bytes.WriteString16Length(data.Xid, buf)

--- a/pkg/protocol/codec/branch_rollback_response_codec_test.go
+++ b/pkg/protocol/codec/branch_rollback_response_codec_test.go
@@ -18,6 +18,7 @@
 package codec
 
 import (
+	"strings"
 	"testing"
 
 	serror "seata.apache.org/seata-go/v2/pkg/util/errors"
@@ -50,4 +51,31 @@ func TestBranchRollbackResponseCodec(t *testing.T) {
 	msg2 := codec.Decode(bytes)
 
 	assert.Equal(t, msg, msg2)
+}
+
+func TestBranchRollbackResponseCodec_TruncatesLongMessageWithoutShiftingFields(t *testing.T) {
+	msg := message.BranchRollbackResponse{
+		AbstractBranchEndResponse: message.AbstractBranchEndResponse{
+			Xid:          "xid",
+			BranchId:     123,
+			BranchStatus: model2.BranchStatusPhasetwoRollbackFailedRetryable,
+			AbstractTransactionResponse: message.AbstractTransactionResponse{
+				TransactionErrorCode: serror.TransactionErrorCodeBranchRollbackFailedRetriable,
+				AbstractResultMessage: message.AbstractResultMessage{
+					ResultCode: message.ResultCodeFailed,
+					Msg:        strings.Repeat("x", 300),
+				},
+			},
+		},
+	}
+
+	codec := BranchRollbackResponseCodec{}
+	decoded := codec.Decode(codec.Encode(msg)).(message.BranchRollbackResponse)
+
+	assert.Equal(t, message.ResultCodeFailed, decoded.ResultCode)
+	assert.Equal(t, strings.Repeat("x", 127), decoded.Msg)
+	assert.Equal(t, msg.TransactionErrorCode, decoded.TransactionErrorCode)
+	assert.Equal(t, msg.Xid, decoded.Xid)
+	assert.Equal(t, msg.BranchId, decoded.BranchId)
+	assert.Equal(t, msg.BranchStatus, decoded.BranchStatus)
 }

--- a/pkg/protocol/codec/branch_rollback_response_codec_test.go
+++ b/pkg/protocol/codec/branch_rollback_response_codec_test.go
@@ -18,6 +18,7 @@
 package codec
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestBranchRollbackResponseCodec_TruncatesLongMessageWithoutShiftingFields(t
 				TransactionErrorCode: serror.TransactionErrorCodeBranchRollbackFailedRetriable,
 				AbstractResultMessage: message.AbstractResultMessage{
 					ResultCode: message.ResultCodeFailed,
-					Msg:        strings.Repeat("x", 300),
+					Msg:        strings.Repeat("x", math.MaxInt16+100),
 				},
 			},
 		},
@@ -73,9 +74,42 @@ func TestBranchRollbackResponseCodec_TruncatesLongMessageWithoutShiftingFields(t
 	decoded := codec.Decode(codec.Encode(msg)).(message.BranchRollbackResponse)
 
 	assert.Equal(t, message.ResultCodeFailed, decoded.ResultCode)
-	assert.Equal(t, strings.Repeat("x", 127), decoded.Msg)
+	assert.Equal(t, strings.Repeat("x", math.MaxInt16), decoded.Msg)
 	assert.Equal(t, msg.TransactionErrorCode, decoded.TransactionErrorCode)
 	assert.Equal(t, msg.Xid, decoded.Xid)
 	assert.Equal(t, msg.BranchId, decoded.BranchId)
 	assert.Equal(t, msg.BranchStatus, decoded.BranchStatus)
+}
+
+// Byte vector derived from Java AbstractResultMessageCodec,
+// AbstractTransactionResponseCodec, and AbstractBranchEndResponseCodec.
+func TestBranchRollbackResponseCodec_JavaWireFormat(t *testing.T) {
+	msg := message.BranchRollbackResponse{
+		AbstractBranchEndResponse: message.AbstractBranchEndResponse{
+			Xid:          "192.168.0.1:8091:1234",
+			BranchId:     5678,
+			BranchStatus: model2.BranchStatusPhasetwoRollbackFailedRetryable,
+			AbstractTransactionResponse: message.AbstractTransactionResponse{
+				TransactionErrorCode: serror.TransactionErrorCodeBranchRollbackFailedRetriable,
+				AbstractResultMessage: message.AbstractResultMessage{
+					ResultCode: message.ResultCodeFailed,
+					Msg:        "storage failed",
+				},
+			},
+		},
+	}
+	want := []byte{
+		0x00,
+		0x00, 0x0e,
+		's', 't', 'o', 'r', 'a', 'g', 'e', ' ', 'f', 'a', 'i', 'l', 'e', 'd',
+		0x04,
+		0x00, 0x15,
+		'1', '9', '2', '.', '1', '6', '8', '.', '0', '.', '1', ':', '8', '0', '9', '1', ':', '1', '2', '3', '4',
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x16, 0x2e,
+		0x09,
+	}
+
+	codec := BranchRollbackResponseCodec{}
+	assert.Equal(t, want, codec.Encode(msg), "encode must reproduce the Java bytes exactly")
+	assert.Equal(t, msg, codec.Decode(want))
 }

--- a/pkg/remoting/processor/client/rm_branch_commit_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor.go
@@ -19,7 +19,6 @@ package client
 
 import (
 	"context"
-	"errors"
 
 	"seata.apache.org/seata-go/v2/pkg/protocol"
 	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
@@ -48,41 +47,7 @@ func initBranchCommit() {
 
 type rmBranchCommitProcessor struct {
 	getResourceManager func(branch.BranchType) rm.ResourceManager
-	sendGrpcResponse   func(int32, interface{}) error
-	sendGettyResponse  func(int32, interface{}) error
-}
-
-// branchEndResult is the protocol-independent result of a branch operation.
-type branchEndResult struct {
-	status     branch.BranchStatus
-	resultCode message.ResultCode
-	errMsg     string
-}
-
-func newBranchEndResult(status branch.BranchStatus, bizErr error) branchEndResult {
-	result := branchEndResult{status: status, resultCode: message.ResultCodeSuccess}
-	if bizErr != nil {
-		result.resultCode = message.ResultCodeFailed
-		result.errMsg = bizErr.Error()
-	}
-	return result
-}
-
-func branchEndProcessError(bizErr, sendErr error) error {
-	if sendErr == nil {
-		return nil
-	}
-	if bizErr == nil {
-		return sendErr
-	}
-	return errors.Join(bizErr, sendErr)
-}
-
-func (f *rmBranchCommitProcessor) resourceManager(branchType branch.BranchType) rm.ResourceManager {
-	if f.getResourceManager != nil {
-		return f.getResourceManager(branchType)
-	}
-	return rm.GetRmCacheInstance().GetResourceManager(branchType)
+	sendResponse       func(int32, interface{}) error
 }
 
 func (f *rmBranchCommitProcessor) Process(ctx context.Context, rpcMessage message.RpcMessage) error {
@@ -109,9 +74,9 @@ func (f *rmBranchCommitProcessor) handleGrpcBranchCommit(ctx context.Context, rp
 		Xid:             xid,
 	}
 
-	status, bizErr := f.resourceManager(branch.BranchType(request.AbstractBranchEndRequest.BranchType)).BranchCommit(ctx, branchResource)
+	status, bizErr := branchEndResourceManager(f.getResourceManager, branch.BranchType(request.AbstractBranchEndRequest.BranchType)).BranchCommit(ctx, branchResource)
 	if bizErr != nil {
-		log.Errorf("branch commit error: %s", bizErr.Error())
+		log.Errorf("branch commit error: xid %s, branchID %d: %s", xid, branchID, bizErr.Error())
 	} else {
 		log.Infof("branch commit success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
@@ -123,7 +88,7 @@ func (f *rmBranchCommitProcessor) handleGrpcBranchCommit(ctx context.Context, rp
 		AbstractBranchEndResponse: &pb.AbstractBranchEndResponseProto{
 			AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
 				AbstractResultMessage: &pb.AbstractResultMessageProto{
-					ResultCode: pb.ResultCodeProto(result.resultCode),
+					ResultCode: branchEndResultCodeProto(result.resultCode),
 					Msg:        result.errMsg,
 				},
 			},
@@ -133,7 +98,7 @@ func (f *rmBranchCommitProcessor) handleGrpcBranchCommit(ctx context.Context, rp
 		},
 	}
 
-	sendResponse := f.sendGrpcResponse
+	sendResponse := f.sendResponse
 	if sendResponse == nil {
 		sendResponse = grpc.GetGrpcRemotingClient().SendAsyncResponse
 	}
@@ -160,9 +125,9 @@ func (f *rmBranchCommitProcessor) handleGettyBranchCommit(ctx context.Context, r
 		Xid:             xid,
 	}
 
-	status, bizErr := f.resourceManager(request.BranchType).BranchCommit(ctx, branchResource)
+	status, bizErr := branchEndResourceManager(f.getResourceManager, request.BranchType).BranchCommit(ctx, branchResource)
 	if bizErr != nil {
-		log.Errorf("branch commit error: %s", bizErr.Error())
+		log.Errorf("branch commit error: xid %s, branchID %d: %s", xid, branchID, bizErr.Error())
 	} else {
 		log.Infof("branch commit success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
@@ -183,7 +148,7 @@ func (f *rmBranchCommitProcessor) handleGettyBranchCommit(ctx context.Context, r
 			BranchStatus: result.status,
 		},
 	}
-	sendResponse := f.sendGettyResponse
+	sendResponse := f.sendResponse
 	if sendResponse == nil {
 		sendResponse = getty.GetGettyRemotingClient().SendAsyncResponse
 	}

--- a/pkg/remoting/processor/client/rm_branch_commit_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor.go
@@ -98,13 +98,10 @@ func (f *rmBranchCommitProcessor) handleGrpcBranchCommit(ctx context.Context, rp
 		},
 	}
 
-	sendResponse := f.sendResponse
-	if sendResponse == nil {
-		sendResponse = grpc.GetGrpcRemotingClient().SendAsyncResponse
-	}
+	sendResponse := branchEndSendResponse(f.sendResponse, grpc.GetGrpcRemotingClient().SendAsyncResponse)
 	sendErr := sendResponse(rpcMessage.ID, response)
 	if sendErr != nil {
-		log.Errorf("send branch commit response error: {%#v}", sendErr.Error())
+		log.Errorf("send branch commit response error: xid %s, branchID %d: %v", xid, branchID, sendErr)
 	} else {
 		log.Infof("send branch commit response success: xid %s, branchID %v, resourceID %v, applicationData %v", xid, branchID, resourceID, applicationData)
 	}
@@ -148,13 +145,10 @@ func (f *rmBranchCommitProcessor) handleGettyBranchCommit(ctx context.Context, r
 			BranchStatus: result.status,
 		},
 	}
-	sendResponse := f.sendResponse
-	if sendResponse == nil {
-		sendResponse = getty.GetGettyRemotingClient().SendAsyncResponse
-	}
+	sendResponse := branchEndSendResponse(f.sendResponse, getty.GetGettyRemotingClient().SendAsyncResponse)
 	sendErr := sendResponse(rpcMessage.ID, response)
 	if sendErr != nil {
-		log.Errorf("send branch commit response error: {%#v}", sendErr.Error())
+		log.Errorf("send branch commit response error: xid %s, branchID %d: %v", xid, branchID, sendErr)
 	} else {
 		log.Infof("send branch commit response success: xid %s, branchID %v, resourceID %v, applicationData %v", xid, branchID, resourceID, applicationData)
 	}

--- a/pkg/remoting/processor/client/rm_branch_commit_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"context"
+	"errors"
 
 	"seata.apache.org/seata-go/v2/pkg/protocol"
 	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
@@ -45,7 +46,44 @@ func initBranchCommit() {
 	}
 }
 
-type rmBranchCommitProcessor struct{}
+type rmBranchCommitProcessor struct {
+	getResourceManager func(branch.BranchType) rm.ResourceManager
+	sendGrpcResponse   func(int32, interface{}) error
+	sendGettyResponse  func(int32, interface{}) error
+}
+
+// branchEndResult is the protocol-independent result of a branch operation.
+type branchEndResult struct {
+	status     branch.BranchStatus
+	resultCode message.ResultCode
+	errMsg     string
+}
+
+func newBranchEndResult(status branch.BranchStatus, bizErr error) branchEndResult {
+	result := branchEndResult{status: status, resultCode: message.ResultCodeSuccess}
+	if bizErr != nil {
+		result.resultCode = message.ResultCodeFailed
+		result.errMsg = bizErr.Error()
+	}
+	return result
+}
+
+func branchEndProcessError(bizErr, sendErr error) error {
+	if sendErr == nil {
+		return nil
+	}
+	if bizErr == nil {
+		return sendErr
+	}
+	return errors.Join(bizErr, sendErr)
+}
+
+func (f *rmBranchCommitProcessor) resourceManager(branchType branch.BranchType) rm.ResourceManager {
+	if f.getResourceManager != nil {
+		return f.getResourceManager(branchType)
+	}
+	return rm.GetRmCacheInstance().GetResourceManager(branchType)
+}
 
 func (f *rmBranchCommitProcessor) Process(ctx context.Context, rpcMessage message.RpcMessage) error {
 	log.Infof("the rm client received  rmBranchCommit rpcMessage %#v from tc server.", rpcMessage)
@@ -71,23 +109,13 @@ func (f *rmBranchCommitProcessor) handleGrpcBranchCommit(ctx context.Context, rp
 		Xid:             xid,
 	}
 
-	status, err := rm.GetRmCacheInstance().GetResourceManager(branch.BranchType(request.AbstractBranchEndRequest.BranchType)).BranchCommit(ctx, branchResource)
-	if err != nil {
-		log.Errorf("branch commit error: %s", err.Error())
-		return err
-	}
-	log.Infof("branch commit success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
-
-	var (
-		resultCode pb.ResultCodeProto
-		errMsg     string
-	)
-	if err != nil {
-		resultCode = pb.ResultCodeProto_Failed
-		errMsg = err.Error()
+	status, bizErr := f.resourceManager(branch.BranchType(request.AbstractBranchEndRequest.BranchType)).BranchCommit(ctx, branchResource)
+	if bizErr != nil {
+		log.Errorf("branch commit error: %s", bizErr.Error())
 	} else {
-		resultCode = pb.ResultCodeProto_Success
+		log.Infof("branch commit success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
+	result := newBranchEndResult(status, bizErr)
 
 	// reply commit response to tc server
 	// todo add TransactionErrorCode
@@ -95,23 +123,27 @@ func (f *rmBranchCommitProcessor) handleGrpcBranchCommit(ctx context.Context, rp
 		AbstractBranchEndResponse: &pb.AbstractBranchEndResponseProto{
 			AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
 				AbstractResultMessage: &pb.AbstractResultMessageProto{
-					ResultCode: resultCode,
-					Msg:        errMsg,
+					ResultCode: pb.ResultCodeProto(result.resultCode),
+					Msg:        result.errMsg,
 				},
 			},
 			Xid:          xid,
 			BranchId:     branchID,
-			BranchStatus: pb.BranchStatusProto(status),
+			BranchStatus: pb.BranchStatusProto(result.status),
 		},
 	}
 
-	err = grpc.GetGrpcRemotingClient().SendAsyncResponse(rpcMessage.ID, response)
-	if err != nil {
-		log.Errorf("send branch commit response error: {%#v}", err.Error())
-		return err
+	sendResponse := f.sendGrpcResponse
+	if sendResponse == nil {
+		sendResponse = grpc.GetGrpcRemotingClient().SendAsyncResponse
 	}
-	log.Infof("send branch commit success: xid %v, branchID %v, resourceID %v, applicationData %v", xid, branchID, resourceID, applicationData)
-	return nil
+	sendErr := sendResponse(rpcMessage.ID, response)
+	if sendErr != nil {
+		log.Errorf("send branch commit response error: {%#v}", sendErr.Error())
+	} else {
+		log.Infof("send branch commit response success: xid %s, branchID %v, resourceID %v, applicationData %v", xid, branchID, resourceID, applicationData)
+	}
+	return branchEndProcessError(bizErr, sendErr)
 }
 
 func (f *rmBranchCommitProcessor) handleGettyBranchCommit(ctx context.Context, rpcMessage message.RpcMessage) error {
@@ -128,23 +160,13 @@ func (f *rmBranchCommitProcessor) handleGettyBranchCommit(ctx context.Context, r
 		Xid:             xid,
 	}
 
-	status, err := rm.GetRmCacheInstance().GetResourceManager(request.BranchType).BranchCommit(ctx, branchResource)
-	if err != nil {
-		log.Errorf("branch commit error: %s", err.Error())
-		return err
-	}
-	log.Infof("branch commit success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
-
-	var (
-		resultCode message.ResultCode
-		errMsg     string
-	)
-	if err != nil {
-		resultCode = message.ResultCodeFailed
-		errMsg = err.Error()
+	status, bizErr := f.resourceManager(request.BranchType).BranchCommit(ctx, branchResource)
+	if bizErr != nil {
+		log.Errorf("branch commit error: %s", bizErr.Error())
 	} else {
-		resultCode = message.ResultCodeSuccess
+		log.Infof("branch commit success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
+	result := newBranchEndResult(status, bizErr)
 
 	// reply commit response to tc server
 	// todo add TransactionErrorCode
@@ -152,20 +174,24 @@ func (f *rmBranchCommitProcessor) handleGettyBranchCommit(ctx context.Context, r
 		AbstractBranchEndResponse: message.AbstractBranchEndResponse{
 			AbstractTransactionResponse: message.AbstractTransactionResponse{
 				AbstractResultMessage: message.AbstractResultMessage{
-					ResultCode: resultCode,
-					Msg:        errMsg,
+					ResultCode: result.resultCode,
+					Msg:        result.errMsg,
 				},
 			},
 			Xid:          xid,
 			BranchId:     branchID,
-			BranchStatus: status,
+			BranchStatus: result.status,
 		},
 	}
-	err = getty.GetGettyRemotingClient().SendAsyncResponse(rpcMessage.ID, response)
-	if err != nil {
-		log.Errorf("send branch commit response error: {%#v}", err.Error())
-		return err
+	sendResponse := f.sendGettyResponse
+	if sendResponse == nil {
+		sendResponse = getty.GetGettyRemotingClient().SendAsyncResponse
 	}
-	log.Infof("send branch commit success: xid %v, branchID %v, resourceID %v, applicationData %v", xid, branchID, resourceID, applicationData)
-	return nil
+	sendErr := sendResponse(rpcMessage.ID, response)
+	if sendErr != nil {
+		log.Errorf("send branch commit response error: {%#v}", sendErr.Error())
+	} else {
+		log.Infof("send branch commit response success: xid %s, branchID %v, resourceID %v, applicationData %v", xid, branchID, resourceID, applicationData)
+	}
+	return branchEndProcessError(bizErr, sendErr)
 }

--- a/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
@@ -58,6 +58,28 @@ func (*testResourceManager) UnregisterResource(rm.Resource) error { return nil }
 func (*testResourceManager) GetCachedResources() *sync.Map        { return &sync.Map{} }
 func (m *testResourceManager) GetBranchType() branch.BranchType   { return m.branchType }
 
+func TestBranchEndSendResponse(t *testing.T) {
+	injectedCalled := false
+	fallbackCalled := false
+	injected := func(int32, interface{}) error {
+		injectedCalled = true
+		return nil
+	}
+	fallback := func(int32, interface{}) error {
+		fallbackCalled = true
+		return nil
+	}
+
+	require.NoError(t, branchEndSendResponse(injected, fallback)(1, "response"))
+	require.True(t, injectedCalled)
+	require.False(t, fallbackCalled)
+
+	injectedCalled = false
+	require.NoError(t, branchEndSendResponse(nil, fallback)(2, "response"))
+	require.False(t, injectedCalled)
+	require.True(t, fallbackCalled)
+}
+
 func TestBranchEndResult(t *testing.T) {
 	bizErr := errors.New("operation failed")
 	failed := newBranchEndResult(branch.BranchStatusPhasetwoCommitFailedRetryable, bizErr)

--- a/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
@@ -19,93 +19,169 @@ package client
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 
-	"seata.apache.org/seata-go/v2/pkg/rm/tcc"
-
-	model2 "seata.apache.org/seata-go/v2/pkg/protocol/branch"
-	"seata.apache.org/seata-go/v2/pkg/protocol/codec"
+	"github.com/stretchr/testify/require"
+	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/protocol/message"
-	"seata.apache.org/seata-go/v2/pkg/remoting/config"
 	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 )
 
-func TestRmBranchCommitProcessor(t *testing.T) {
-	// testcases
-	tests := []struct {
-		name     string             // testcase name
-		protocol string             // protocol:seata/grpc
-		rpcMsg   message.RpcMessage // rpcMessage case
-		wantErr  bool               // want testcase err or not
-	}{
-		{
-			name:     "rbc-testcase1-failure",
-			protocol: "seata",
-			rpcMsg: message.RpcMessage{
-				ID:         123,
-				Type:       message.RequestType(message.MessageTypeBranchCommit),
-				Codec:      byte(codec.CodecTypeSeata),
-				Compressor: byte(1),
-				HeadMap: map[string]string{
-					"name":    " Jack",
-					"age":     "12",
-					"address": "Beijing",
-				},
-				Body: message.BranchCommitRequest{
-					AbstractBranchEndRequest: message.AbstractBranchEndRequest{
-						Xid:             "123344",
-						BranchId:        56678,
-						BranchType:      model2.BranchTypeTCC,
-						ResourceId:      "1232323",
-						ApplicationData: []byte("TestExtraData"),
-					},
-				},
-			},
+type testResourceManager struct {
+	commitStatus   branch.BranchStatus
+	commitErr      error
+	rollbackStatus branch.BranchStatus
+	rollbackErr    error
+}
 
-			wantErr: true, // need dail to server, so err accured
-		},
-		{
-			name:     "rbc-testcase2-failure",
-			protocol: "grpc",
-			rpcMsg: message.RpcMessage{
-				ID:   123,
-				Type: message.RequestType(message.MessageTypeBranchCommit),
-				HeadMap: map[string]string{
-					"name":    " Jack",
-					"age":     "12",
-					"address": "Beijing",
-				},
-				Body: &pb.BranchCommitRequestProto{
-					AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{
-						Xid:             "123345",
-						BranchId:        56679,
-						BranchType:      pb.BranchTypeProto_TCC,
-						ResourceId:      "1232324",
-						ApplicationData: "TestExtraData",
-					},
-				},
-			},
+func (m *testResourceManager) BranchCommit(context.Context, rm.BranchResource) (branch.BranchStatus, error) {
+	return m.commitStatus, m.commitErr
+}
+func (m *testResourceManager) BranchRollback(context.Context, rm.BranchResource) (branch.BranchStatus, error) {
+	return m.rollbackStatus, m.rollbackErr
+}
+func (*testResourceManager) BranchRegister(context.Context, rm.BranchRegisterParam) (int64, error) {
+	return 0, nil
+}
+func (*testResourceManager) BranchReport(context.Context, rm.BranchReportParam) error { return nil }
+func (*testResourceManager) LockQuery(context.Context, rm.LockQueryParam) (bool, error) {
+	return false, nil
+}
+func (*testResourceManager) RegisterResource(rm.Resource) error   { return nil }
+func (*testResourceManager) UnregisterResource(rm.Resource) error { return nil }
+func (*testResourceManager) GetCachedResources() *sync.Map        { return &sync.Map{} }
+func (*testResourceManager) GetBranchType() branch.BranchType     { return branch.BranchTypeTCC }
 
-			wantErr: true, // need dail to server, so err accured
-		},
-	}
+func TestBranchEndResult(t *testing.T) {
+	bizErr := errors.New("operation failed")
+	failed := newBranchEndResult(branch.BranchStatusPhasetwoCommitFailedRetryable, bizErr)
+	require.Equal(t, message.ResultCodeFailed, failed.resultCode)
+	require.Equal(t, bizErr.Error(), failed.errMsg)
 
-	var ctx context.Context
-	var rbcProcessor rmBranchCommitProcessor
+	success := newBranchEndResult(branch.BranchStatusPhasetwoCommitted, nil)
+	require.Equal(t, message.ResultCodeSuccess, success.resultCode)
+	require.Empty(t, success.errMsg)
 
-	// run tests
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			config.InitTransportConfig(&config.TransportConfig{Protocol: tc.protocol})
+	sendErr := errors.New("send failed")
+	require.NoError(t, branchEndProcessError(bizErr, nil))
+	require.ErrorIs(t, branchEndProcessError(nil, sendErr), sendErr)
+	combined := branchEndProcessError(bizErr, sendErr)
+	require.ErrorIs(t, combined, bizErr)
+	require.ErrorIs(t, combined, sendErr)
+}
 
-			rm.GetRmCacheInstance().RegisterResourceManager(tcc.GetTCCResourceManagerInstance())
+func TestRmBranchCommitProcessor_SendsFailureResponse(t *testing.T) {
+	bizErr := errors.New("commit failed")
+	manager := &testResourceManager{commitStatus: branch.BranchStatusPhasetwoCommitFailedRetryable, commitErr: bizErr}
 
-			err := rbcProcessor.Process(ctx, tc.rpcMsg)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("rmBranchCommitProcessor wantErr: %v, got: %v", tc.wantErr, err)
-				return
-			}
-		})
-	}
+	t.Run("getty", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchCommitProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGettyBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchCommitRequest{
+			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(message.BranchCommitResponse)
+		require.Equal(t, message.ResultCodeFailed, got.ResultCode)
+		require.Equal(t, bizErr.Error(), got.Msg)
+		require.Equal(t, manager.commitStatus, got.BranchStatus)
+		require.Equal(t, "xid", got.Xid)
+		require.Equal(t, int64(7), got.BranchId)
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchCommitProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGrpcBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchCommitRequestProto{
+			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(*pb.BranchCommitResponseProto)
+		result := got.AbstractBranchEndResponse.AbstractTransactionResponse.AbstractResultMessage
+		require.Equal(t, pb.ResultCodeProto_Failed, result.ResultCode)
+		require.Equal(t, bizErr.Error(), result.Msg)
+		require.Equal(t, pb.BranchStatusProto(manager.commitStatus), got.AbstractBranchEndResponse.BranchStatus)
+		require.Equal(t, "xid", got.AbstractBranchEndResponse.Xid)
+		require.Equal(t, int64(7), got.AbstractBranchEndResponse.BranchId)
+	})
+}
+
+func TestRmBranchCommitProcessor_ObservesBusinessAndSendErrors(t *testing.T) {
+	bizErr := errors.New("commit failed")
+	sendErr := errors.New("send failed")
+	manager := &testResourceManager{commitStatus: branch.BranchStatusPhasetwoCommitFailedRetryable, commitErr: bizErr}
+
+	t.Run("getty", func(t *testing.T) {
+		processor := rmBranchCommitProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGettyResponse:  func(int32, interface{}) error { return sendErr },
+		}
+		err := processor.handleGettyBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchCommitRequest{
+			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
+		}})
+		require.ErrorIs(t, err, bizErr)
+		require.ErrorIs(t, err, sendErr)
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		processor := rmBranchCommitProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGrpcResponse:   func(int32, interface{}) error { return sendErr },
+		}
+		err := processor.handleGrpcBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchCommitRequestProto{
+			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
+		}})
+		require.ErrorIs(t, err, bizErr)
+		require.ErrorIs(t, err, sendErr)
+	})
+}
+
+func TestRmBranchCommitProcessor_SendsSuccessResponse(t *testing.T) {
+	manager := &testResourceManager{commitStatus: branch.BranchStatusPhasetwoCommitted}
+
+	t.Run("getty", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchCommitProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGettyBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchCommitRequest{
+			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(message.BranchCommitResponse)
+		require.Equal(t, message.ResultCodeSuccess, got.ResultCode)
+		require.Empty(t, got.Msg)
+		require.Equal(t, manager.commitStatus, got.BranchStatus)
+		require.Equal(t, "xid", got.Xid)
+		require.Equal(t, int64(7), got.BranchId)
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchCommitProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGrpcBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchCommitRequestProto{
+			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(*pb.BranchCommitResponseProto)
+		result := got.AbstractBranchEndResponse.AbstractTransactionResponse.AbstractResultMessage
+		require.Equal(t, pb.ResultCodeProto_Success, result.ResultCode)
+		require.Empty(t, result.Msg)
+		require.Equal(t, pb.BranchStatusProto(manager.commitStatus), got.AbstractBranchEndResponse.BranchStatus)
+		require.Equal(t, "xid", got.AbstractBranchEndResponse.Xid)
+		require.Equal(t, int64(7), got.AbstractBranchEndResponse.BranchId)
+	})
 }

--- a/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
@@ -24,13 +24,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"seata.apache.org/seata-go/v2/pkg/protocol"
 	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/protocol/message"
+	"seata.apache.org/seata-go/v2/pkg/remoting/config"
 	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 )
 
 type testResourceManager struct {
+	branchType     branch.BranchType
 	commitStatus   branch.BranchStatus
 	commitErr      error
 	rollbackStatus branch.BranchStatus
@@ -53,16 +56,18 @@ func (*testResourceManager) LockQuery(context.Context, rm.LockQueryParam) (bool,
 func (*testResourceManager) RegisterResource(rm.Resource) error   { return nil }
 func (*testResourceManager) UnregisterResource(rm.Resource) error { return nil }
 func (*testResourceManager) GetCachedResources() *sync.Map        { return &sync.Map{} }
-func (*testResourceManager) GetBranchType() branch.BranchType     { return branch.BranchTypeTCC }
+func (m *testResourceManager) GetBranchType() branch.BranchType   { return m.branchType }
 
 func TestBranchEndResult(t *testing.T) {
 	bizErr := errors.New("operation failed")
 	failed := newBranchEndResult(branch.BranchStatusPhasetwoCommitFailedRetryable, bizErr)
 	require.Equal(t, message.ResultCodeFailed, failed.resultCode)
+	require.Equal(t, pb.ResultCodeProto_Failed, branchEndResultCodeProto(failed.resultCode))
 	require.Equal(t, bizErr.Error(), failed.errMsg)
 
 	success := newBranchEndResult(branch.BranchStatusPhasetwoCommitted, nil)
 	require.Equal(t, message.ResultCodeSuccess, success.resultCode)
+	require.Equal(t, pb.ResultCodeProto_Success, branchEndResultCodeProto(success.resultCode))
 	require.Empty(t, success.errMsg)
 
 	sendErr := errors.New("send failed")
@@ -71,6 +76,19 @@ func TestBranchEndResult(t *testing.T) {
 	combined := branchEndProcessError(bizErr, sendErr)
 	require.ErrorIs(t, combined, bizErr)
 	require.ErrorIs(t, combined, sendErr)
+
+	injectedManager := &testResourceManager{}
+	require.Same(t, injectedManager, branchEndResourceManager(
+		func(branch.BranchType) rm.ResourceManager { return injectedManager },
+		branch.BranchTypeTCC,
+	))
+
+	fallbackType := branch.BranchType(99)
+	fallbackManager := &testResourceManager{branchType: fallbackType}
+	rmCache := rm.GetRmCacheInstance()
+	rmCache.RegisterResourceManager(fallbackManager)
+	t.Cleanup(func() { rmCache.UnregisterResourceManager(fallbackType) })
+	require.Same(t, fallbackManager, branchEndResourceManager(nil, fallbackType))
 }
 
 func TestRmBranchCommitProcessor_SendsFailureResponse(t *testing.T) {
@@ -81,7 +99,7 @@ func TestRmBranchCommitProcessor_SendsFailureResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchCommitProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGettyBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchCommitRequest{
 			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
@@ -99,7 +117,7 @@ func TestRmBranchCommitProcessor_SendsFailureResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchCommitProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGrpcBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchCommitRequestProto{
 			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
@@ -123,7 +141,7 @@ func TestRmBranchCommitProcessor_ObservesBusinessAndSendErrors(t *testing.T) {
 	t.Run("getty", func(t *testing.T) {
 		processor := rmBranchCommitProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGettyResponse:  func(int32, interface{}) error { return sendErr },
+			sendResponse:       func(int32, interface{}) error { return sendErr },
 		}
 		err := processor.handleGettyBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchCommitRequest{
 			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
@@ -135,7 +153,7 @@ func TestRmBranchCommitProcessor_ObservesBusinessAndSendErrors(t *testing.T) {
 	t.Run("grpc", func(t *testing.T) {
 		processor := rmBranchCommitProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGrpcResponse:   func(int32, interface{}) error { return sendErr },
+			sendResponse:       func(int32, interface{}) error { return sendErr },
 		}
 		err := processor.handleGrpcBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchCommitRequestProto{
 			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
@@ -152,7 +170,7 @@ func TestRmBranchCommitProcessor_SendsSuccessResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchCommitProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGettyBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchCommitRequest{
 			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
@@ -170,7 +188,7 @@ func TestRmBranchCommitProcessor_SendsSuccessResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchCommitProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGrpcBranchCommit(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchCommitRequestProto{
 			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
@@ -184,4 +202,48 @@ func TestRmBranchCommitProcessor_SendsSuccessResponse(t *testing.T) {
 		require.Equal(t, "xid", got.AbstractBranchEndResponse.Xid)
 		require.Equal(t, int64(7), got.AbstractBranchEndResponse.BranchId)
 	})
+}
+
+func TestRmBranchCommitProcessor_ProcessRoutesByProtocol(t *testing.T) {
+	previous := config.GetTransportConfig()
+	t.Cleanup(func() { config.InitTransportConfig(previous) })
+
+	manager := &testResourceManager{commitStatus: branch.BranchStatusPhasetwoCommitted}
+	tests := []struct {
+		name     string
+		protocol protocol.Protocol
+		body     interface{}
+		wantType interface{}
+	}{
+		{
+			name:     "seata",
+			protocol: protocol.ProtocolSEATA,
+			body: message.BranchCommitRequest{AbstractBranchEndRequest: message.AbstractBranchEndRequest{
+				Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource",
+			}},
+			wantType: message.BranchCommitResponse{},
+		},
+		{
+			name:     "grpc",
+			protocol: protocol.ProtocolGRPC,
+			body: &pb.BranchCommitRequestProto{AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{
+				Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource",
+			}},
+			wantType: (*pb.BranchCommitResponseProto)(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.InitTransportConfig(&config.TransportConfig{Protocol: tt.protocol.String()})
+			var sent interface{}
+			processor := rmBranchCommitProcessor{
+				getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+				sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
+			}
+
+			require.NoError(t, processor.Process(context.Background(), message.RpcMessage{ID: 1, Body: tt.body}))
+			require.IsType(t, tt.wantType, sent)
+		})
+	}
 }

--- a/pkg/remoting/processor/client/rm_branch_end_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_end_processor.go
@@ -49,6 +49,16 @@ func branchEndResultCodeProto(resultCode message.ResultCode) pb.ResultCodeProto 
 	return pb.ResultCodeProto_Success
 }
 
+func branchEndSendResponse(
+	sendResponse func(int32, interface{}) error,
+	fallback func(int32, interface{}) error,
+) func(int32, interface{}) error {
+	if sendResponse != nil {
+		return sendResponse
+	}
+	return fallback
+}
+
 func branchEndProcessError(bizErr, sendErr error) error {
 	if sendErr == nil {
 		return nil

--- a/pkg/remoting/processor/client/rm_branch_end_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_end_processor.go
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"errors"
+
+	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
+	"seata.apache.org/seata-go/v2/pkg/protocol/message"
+	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
+	"seata.apache.org/seata-go/v2/pkg/rm"
+)
+
+// branchEndResult is the protocol-independent result of a branch operation.
+type branchEndResult struct {
+	status     branch.BranchStatus
+	resultCode message.ResultCode
+	errMsg     string
+}
+
+func newBranchEndResult(status branch.BranchStatus, bizErr error) branchEndResult {
+	result := branchEndResult{status: status, resultCode: message.ResultCodeSuccess}
+	if bizErr != nil {
+		result.resultCode = message.ResultCodeFailed
+		result.errMsg = bizErr.Error()
+	}
+	return result
+}
+
+func branchEndResultCodeProto(resultCode message.ResultCode) pb.ResultCodeProto {
+	if resultCode == message.ResultCodeFailed {
+		return pb.ResultCodeProto_Failed
+	}
+	return pb.ResultCodeProto_Success
+}
+
+func branchEndProcessError(bizErr, sendErr error) error {
+	if sendErr == nil {
+		return nil
+	}
+	if bizErr == nil {
+		return sendErr
+	}
+	return errors.Join(bizErr, sendErr)
+}
+
+func branchEndResourceManager(
+	getResourceManager func(branch.BranchType) rm.ResourceManager,
+	branchType branch.BranchType,
+) rm.ResourceManager {
+	if getResourceManager != nil {
+		return getResourceManager(branchType)
+	}
+	return rm.GetRmCacheInstance().GetResourceManager(branchType)
+}

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor.go
@@ -47,15 +47,7 @@ func initBranchRollback() {
 
 type rmBranchRollbackProcessor struct {
 	getResourceManager func(branch.BranchType) rm.ResourceManager
-	sendGrpcResponse   func(int32, interface{}) error
-	sendGettyResponse  func(int32, interface{}) error
-}
-
-func (f *rmBranchRollbackProcessor) resourceManager(branchType branch.BranchType) rm.ResourceManager {
-	if f.getResourceManager != nil {
-		return f.getResourceManager(branchType)
-	}
-	return rm.GetRmCacheInstance().GetResourceManager(branchType)
+	sendResponse       func(int32, interface{}) error
 }
 
 func (f *rmBranchRollbackProcessor) Process(ctx context.Context, rpcMessage message.RpcMessage) error {
@@ -84,19 +76,19 @@ func (f *rmBranchRollbackProcessor) handleGrpcBranchRollback(ctx context.Context
 		ResourceId:      resourceID,
 		ApplicationData: []byte(applicationData),
 	}
-	status, bizErr := f.resourceManager(branchType).BranchRollback(ctx, branchResource)
+	status, bizErr := branchEndResourceManager(f.getResourceManager, branchType).BranchRollback(ctx, branchResource)
 	if bizErr != nil {
-		log.Errorf("branch rollback error: %s", bizErr.Error())
+		log.Errorf("branch rollback error: xid %s, branchID %d: %s", xid, branchID, bizErr.Error())
 	} else {
 		log.Infof("branch rollback success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
 	result := newBranchEndResult(status, bizErr)
-	// reply commit response to tc server
+	// reply rollback response to tc server
 	response := &pb.BranchRollbackResponseProto{
 		AbstractBranchEndResponse: &pb.AbstractBranchEndResponseProto{
 			AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
 				AbstractResultMessage: &pb.AbstractResultMessageProto{
-					ResultCode: pb.ResultCodeProto(result.resultCode),
+					ResultCode: branchEndResultCodeProto(result.resultCode),
 					Msg:        result.errMsg,
 				},
 			},
@@ -105,7 +97,7 @@ func (f *rmBranchRollbackProcessor) handleGrpcBranchRollback(ctx context.Context
 			BranchStatus: pb.BranchStatusProto(result.status),
 		},
 	}
-	sendResponse := f.sendGrpcResponse
+	sendResponse := f.sendResponse
 	if sendResponse == nil {
 		sendResponse = grpc.GetGrpcRemotingClient().SendAsyncResponse
 	}
@@ -132,14 +124,14 @@ func (f *rmBranchRollbackProcessor) handleGettyBranchRollback(ctx context.Contex
 		ResourceId:      resourceID,
 		ApplicationData: applicationData,
 	}
-	status, bizErr := f.resourceManager(request.BranchType).BranchRollback(ctx, branchResource)
+	status, bizErr := branchEndResourceManager(f.getResourceManager, request.BranchType).BranchRollback(ctx, branchResource)
 	if bizErr != nil {
-		log.Errorf("branch rollback error: %s", bizErr.Error())
+		log.Errorf("branch rollback error: xid %s, branchID %d: %s", xid, branchID, bizErr.Error())
 	} else {
 		log.Infof("branch rollback success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
 	result := newBranchEndResult(status, bizErr)
-	// reply commit response to tc server
+	// reply rollback response to tc server
 	response := message.BranchRollbackResponse{
 		AbstractBranchEndResponse: message.AbstractBranchEndResponse{
 			AbstractTransactionResponse: message.AbstractTransactionResponse{
@@ -153,7 +145,7 @@ func (f *rmBranchRollbackProcessor) handleGettyBranchRollback(ctx context.Contex
 			BranchStatus: result.status,
 		},
 	}
-	sendResponse := f.sendGettyResponse
+	sendResponse := f.sendResponse
 	if sendResponse == nil {
 		sendResponse = getty.GetGettyRemotingClient().SendAsyncResponse
 	}

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor.go
@@ -97,13 +97,10 @@ func (f *rmBranchRollbackProcessor) handleGrpcBranchRollback(ctx context.Context
 			BranchStatus: pb.BranchStatusProto(result.status),
 		},
 	}
-	sendResponse := f.sendResponse
-	if sendResponse == nil {
-		sendResponse = grpc.GetGrpcRemotingClient().SendAsyncResponse
-	}
+	sendResponse := branchEndSendResponse(f.sendResponse, grpc.GetGrpcRemotingClient().SendAsyncResponse)
 	sendErr := sendResponse(rpcMessage.ID, response)
 	if sendErr != nil {
-		log.Errorf("send branch rollback response error: {%#v}", sendErr.Error())
+		log.Errorf("send branch rollback response error: xid %s, branchID %d: %v", xid, branchID, sendErr)
 	} else {
 		log.Infof("send branch rollback response success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
@@ -145,13 +142,10 @@ func (f *rmBranchRollbackProcessor) handleGettyBranchRollback(ctx context.Contex
 			BranchStatus: result.status,
 		},
 	}
-	sendResponse := f.sendResponse
-	if sendResponse == nil {
-		sendResponse = getty.GetGettyRemotingClient().SendAsyncResponse
-	}
+	sendResponse := branchEndSendResponse(f.sendResponse, getty.GetGettyRemotingClient().SendAsyncResponse)
 	sendErr := sendResponse(rpcMessage.ID, response)
 	if sendErr != nil {
-		log.Errorf("send branch rollback response error: {%#v}", sendErr.Error())
+		log.Errorf("send branch rollback response error: xid %s, branchID %d: %v", xid, branchID, sendErr)
 	} else {
 		log.Infof("send branch rollback response success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor.go
@@ -45,7 +45,18 @@ func initBranchRollback() {
 	}
 }
 
-type rmBranchRollbackProcessor struct{}
+type rmBranchRollbackProcessor struct {
+	getResourceManager func(branch.BranchType) rm.ResourceManager
+	sendGrpcResponse   func(int32, interface{}) error
+	sendGettyResponse  func(int32, interface{}) error
+}
+
+func (f *rmBranchRollbackProcessor) resourceManager(branchType branch.BranchType) rm.ResourceManager {
+	if f.getResourceManager != nil {
+		return f.getResourceManager(branchType)
+	}
+	return rm.GetRmCacheInstance().GetResourceManager(branchType)
+}
 
 func (f *rmBranchRollbackProcessor) Process(ctx context.Context, rpcMessage message.RpcMessage) error {
 	log.Infof("the rm client received  rmBranchRollback rpcMessage %#v from tc server.", rpcMessage)
@@ -73,44 +84,38 @@ func (f *rmBranchRollbackProcessor) handleGrpcBranchRollback(ctx context.Context
 		ResourceId:      resourceID,
 		ApplicationData: []byte(applicationData),
 	}
-	status, err := rm.GetRmCacheInstance().GetResourceManager(branchType).BranchRollback(ctx, branchResource)
-	if err != nil {
-		log.Errorf("branch rollback error: %s", err.Error())
-		return err
-	}
-	log.Infof("branch rollback success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
-
-	var (
-		resultCode pb.ResultCodeProto
-		errMsg     string
-	)
-	if err != nil {
-		resultCode = pb.ResultCodeProto_Failed
-		errMsg = err.Error()
+	status, bizErr := f.resourceManager(branchType).BranchRollback(ctx, branchResource)
+	if bizErr != nil {
+		log.Errorf("branch rollback error: %s", bizErr.Error())
 	} else {
-		resultCode = pb.ResultCodeProto_Success
+		log.Infof("branch rollback success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
+	result := newBranchEndResult(status, bizErr)
 	// reply commit response to tc server
 	response := &pb.BranchRollbackResponseProto{
 		AbstractBranchEndResponse: &pb.AbstractBranchEndResponseProto{
 			AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
 				AbstractResultMessage: &pb.AbstractResultMessageProto{
-					ResultCode: resultCode,
-					Msg:        errMsg,
+					ResultCode: pb.ResultCodeProto(result.resultCode),
+					Msg:        result.errMsg,
 				},
 			},
 			Xid:          xid,
 			BranchId:     branchID,
-			BranchStatus: pb.BranchStatusProto(status),
+			BranchStatus: pb.BranchStatusProto(result.status),
 		},
 	}
-	err = grpc.GetGrpcRemotingClient().SendAsyncResponse(rpcMessage.ID, response)
-	if err != nil {
-		log.Errorf("send branch rollback response error: {%#v}", err.Error())
-		return err
+	sendResponse := f.sendGrpcResponse
+	if sendResponse == nil {
+		sendResponse = grpc.GetGrpcRemotingClient().SendAsyncResponse
 	}
-	log.Infof("send branch rollback response success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
-	return nil
+	sendErr := sendResponse(rpcMessage.ID, response)
+	if sendErr != nil {
+		log.Errorf("send branch rollback response error: {%#v}", sendErr.Error())
+	} else {
+		log.Infof("send branch rollback response success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
+	}
+	return branchEndProcessError(bizErr, sendErr)
 }
 
 func (f *rmBranchRollbackProcessor) handleGettyBranchRollback(ctx context.Context, rpcMessage message.RpcMessage) error {
@@ -127,42 +132,36 @@ func (f *rmBranchRollbackProcessor) handleGettyBranchRollback(ctx context.Contex
 		ResourceId:      resourceID,
 		ApplicationData: applicationData,
 	}
-	status, err := rm.GetRmCacheInstance().GetResourceManager(request.BranchType).BranchRollback(ctx, branchResource)
-	if err != nil {
-		log.Errorf("branch rollback error: %s", err.Error())
-		return err
-	}
-	log.Infof("branch rollback success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
-
-	var (
-		resultCode message.ResultCode
-		errMsg     string
-	)
-	if err != nil {
-		resultCode = message.ResultCodeFailed
-		errMsg = err.Error()
+	status, bizErr := f.resourceManager(request.BranchType).BranchRollback(ctx, branchResource)
+	if bizErr != nil {
+		log.Errorf("branch rollback error: %s", bizErr.Error())
 	} else {
-		resultCode = message.ResultCodeSuccess
+		log.Infof("branch rollback success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
 	}
+	result := newBranchEndResult(status, bizErr)
 	// reply commit response to tc server
 	response := message.BranchRollbackResponse{
 		AbstractBranchEndResponse: message.AbstractBranchEndResponse{
 			AbstractTransactionResponse: message.AbstractTransactionResponse{
 				AbstractResultMessage: message.AbstractResultMessage{
-					ResultCode: resultCode,
-					Msg:        errMsg,
+					ResultCode: result.resultCode,
+					Msg:        result.errMsg,
 				},
 			},
 			Xid:          xid,
 			BranchId:     branchID,
-			BranchStatus: status,
+			BranchStatus: result.status,
 		},
 	}
-	err = getty.GetGettyRemotingClient().SendAsyncResponse(rpcMessage.ID, response)
-	if err != nil {
-		log.Errorf("send branch rollback response error: {%#v}", err.Error())
-		return err
+	sendResponse := f.sendGettyResponse
+	if sendResponse == nil {
+		sendResponse = getty.GetGettyRemotingClient().SendAsyncResponse
 	}
-	log.Infof("send branch rollback response success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
-	return nil
+	sendErr := sendResponse(rpcMessage.ID, response)
+	if sendErr != nil {
+		log.Errorf("send branch rollback response error: {%#v}", sendErr.Error())
+	} else {
+		log.Infof("send branch rollback response success: xid %s, branchID %d, resourceID %s, applicationData %s", xid, branchID, resourceID, applicationData)
+	}
+	return branchEndProcessError(bizErr, sendErr)
 }

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor_test.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor_test.go
@@ -19,93 +19,125 @@ package client
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"seata.apache.org/seata-go/v2/pkg/rm/tcc"
-
-	model2 "seata.apache.org/seata-go/v2/pkg/protocol/branch"
-	"seata.apache.org/seata-go/v2/pkg/protocol/codec"
+	"github.com/stretchr/testify/require"
+	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/protocol/message"
-	"seata.apache.org/seata-go/v2/pkg/remoting/config"
 	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 )
 
-func TestRmBranchRollbackProcessor(t *testing.T) {
-	// testcases
-	tests := []struct {
-		name     string             // testcase name
-		protocol string             // protocol:seata/grpc
-		rpcMsg   message.RpcMessage // rpcMessage case
-		wantErr  bool               // want testcase err or not
-	}{
-		{
-			name:     "rbr-testcase1-failure",
-			protocol: "seata",
-			rpcMsg: message.RpcMessage{
-				ID:         223,
-				Type:       message.RequestType(message.MessageTypeBranchRollback),
-				Codec:      byte(codec.CodecTypeSeata),
-				Compressor: byte(1),
-				HeadMap: map[string]string{
-					"name":    " Jack",
-					"age":     "12",
-					"address": "Beijing",
-				},
-				Body: message.BranchRollbackRequest{
-					AbstractBranchEndRequest: message.AbstractBranchEndRequest{
-						Xid:             "123345",
-						BranchId:        56679,
-						BranchType:      model2.BranchTypeTCC,
-						ResourceId:      "1232324",
-						ApplicationData: []byte("TestExtraData"),
-					},
-				},
-			},
+func TestRmBranchRollbackProcessor_SendsFailureResponse(t *testing.T) {
+	bizErr := errors.New("rollback failed")
+	manager := &testResourceManager{rollbackStatus: branch.BranchStatusPhasetwoRollbackFailedRetryable, rollbackErr: bizErr}
 
-			wantErr: true, // need dail to server, so err accured
-		},
-		{
-			name:     "rbr-testcase2-failure",
-			protocol: "grpc",
-			rpcMsg: message.RpcMessage{
-				ID:   223,
-				Type: message.RequestType(message.MessageTypeBranchRollback),
-				HeadMap: map[string]string{
-					"name":    " Jack",
-					"age":     "12",
-					"address": "Beijing",
-				},
-				Body: &pb.BranchRollbackRequestProto{
-					AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{
-						Xid:             "123345",
-						BranchId:        56679,
-						BranchType:      pb.BranchTypeProto_TCC,
-						ResourceId:      "1232324",
-						ApplicationData: "TestExtraData",
-					},
-				},
-			},
+	t.Run("getty", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchRollbackProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGettyBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchRollbackRequest{
+			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(message.BranchRollbackResponse)
+		require.Equal(t, message.ResultCodeFailed, got.ResultCode)
+		require.Equal(t, bizErr.Error(), got.Msg)
+		require.Equal(t, manager.rollbackStatus, got.BranchStatus)
+		require.Equal(t, "xid", got.Xid)
+		require.Equal(t, int64(7), got.BranchId)
+	})
 
-			wantErr: true, // need dail to server, so err accured
-		},
-	}
+	t.Run("grpc", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchRollbackProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGrpcBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchRollbackRequestProto{
+			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(*pb.BranchRollbackResponseProto)
+		result := got.AbstractBranchEndResponse.AbstractTransactionResponse.AbstractResultMessage
+		require.Equal(t, pb.ResultCodeProto_Failed, result.ResultCode)
+		require.Equal(t, bizErr.Error(), result.Msg)
+		require.Equal(t, pb.BranchStatusProto(manager.rollbackStatus), got.AbstractBranchEndResponse.BranchStatus)
+		require.Equal(t, "xid", got.AbstractBranchEndResponse.Xid)
+		require.Equal(t, int64(7), got.AbstractBranchEndResponse.BranchId)
+	})
+}
 
-	var ctx context.Context
-	var rbrProcessor rmBranchRollbackProcessor
+func TestRmBranchRollbackProcessor_ObservesBusinessAndSendErrors(t *testing.T) {
+	bizErr := errors.New("rollback failed")
+	sendErr := errors.New("send failed")
+	manager := &testResourceManager{rollbackStatus: branch.BranchStatusPhasetwoRollbackFailedRetryable, rollbackErr: bizErr}
 
-	// run tests
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			config.InitTransportConfig(&config.TransportConfig{Protocol: tc.protocol})
+	t.Run("getty", func(t *testing.T) {
+		processor := rmBranchRollbackProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGettyResponse:  func(int32, interface{}) error { return sendErr },
+		}
+		err := processor.handleGettyBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchRollbackRequest{
+			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
+		}})
+		require.ErrorIs(t, err, bizErr)
+		require.ErrorIs(t, err, sendErr)
+	})
 
-			rm.GetRmCacheInstance().RegisterResourceManager(tcc.GetTCCResourceManagerInstance())
+	t.Run("grpc", func(t *testing.T) {
+		processor := rmBranchRollbackProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGrpcResponse:   func(int32, interface{}) error { return sendErr },
+		}
+		err := processor.handleGrpcBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchRollbackRequestProto{
+			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
+		}})
+		require.ErrorIs(t, err, bizErr)
+		require.ErrorIs(t, err, sendErr)
+	})
+}
 
-			err := rbrProcessor.Process(ctx, tc.rpcMsg)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("rmBranchRollbackProcessor wantErr: %v, got: %v", tc.wantErr, err)
-				return
-			}
-		})
-	}
+func TestRmBranchRollbackProcessor_SendsSuccessResponse(t *testing.T) {
+	manager := &testResourceManager{rollbackStatus: branch.BranchStatusPhasetwoRollbacked}
+
+	t.Run("getty", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchRollbackProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGettyBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchRollbackRequest{
+			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(message.BranchRollbackResponse)
+		require.Equal(t, message.ResultCodeSuccess, got.ResultCode)
+		require.Empty(t, got.Msg)
+		require.Equal(t, manager.rollbackStatus, got.BranchStatus)
+		require.Equal(t, "xid", got.Xid)
+		require.Equal(t, int64(7), got.BranchId)
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		var sent interface{}
+		processor := rmBranchRollbackProcessor{
+			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+		}
+		err := processor.handleGrpcBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchRollbackRequestProto{
+			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
+		}})
+		require.NoError(t, err)
+		got := sent.(*pb.BranchRollbackResponseProto)
+		result := got.AbstractBranchEndResponse.AbstractTransactionResponse.AbstractResultMessage
+		require.Equal(t, pb.ResultCodeProto_Success, result.ResultCode)
+		require.Empty(t, result.Msg)
+		require.Equal(t, pb.BranchStatusProto(manager.rollbackStatus), got.AbstractBranchEndResponse.BranchStatus)
+		require.Equal(t, "xid", got.AbstractBranchEndResponse.Xid)
+		require.Equal(t, int64(7), got.AbstractBranchEndResponse.BranchId)
+	})
 }

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor_test.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor_test.go
@@ -23,8 +23,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"seata.apache.org/seata-go/v2/pkg/protocol"
 	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/protocol/message"
+	"seata.apache.org/seata-go/v2/pkg/remoting/config"
 	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 )
@@ -37,7 +39,7 @@ func TestRmBranchRollbackProcessor_SendsFailureResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchRollbackProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGettyBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchRollbackRequest{
 			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
@@ -55,7 +57,7 @@ func TestRmBranchRollbackProcessor_SendsFailureResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchRollbackProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGrpcBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchRollbackRequestProto{
 			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
@@ -79,7 +81,7 @@ func TestRmBranchRollbackProcessor_ObservesBusinessAndSendErrors(t *testing.T) {
 	t.Run("getty", func(t *testing.T) {
 		processor := rmBranchRollbackProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGettyResponse:  func(int32, interface{}) error { return sendErr },
+			sendResponse:       func(int32, interface{}) error { return sendErr },
 		}
 		err := processor.handleGettyBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchRollbackRequest{
 			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
@@ -91,7 +93,7 @@ func TestRmBranchRollbackProcessor_ObservesBusinessAndSendErrors(t *testing.T) {
 	t.Run("grpc", func(t *testing.T) {
 		processor := rmBranchRollbackProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGrpcResponse:   func(int32, interface{}) error { return sendErr },
+			sendResponse:       func(int32, interface{}) error { return sendErr },
 		}
 		err := processor.handleGrpcBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchRollbackRequestProto{
 			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
@@ -108,7 +110,7 @@ func TestRmBranchRollbackProcessor_SendsSuccessResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchRollbackProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGettyResponse:  func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGettyBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: message.BranchRollbackRequest{
 			AbstractBranchEndRequest: message.AbstractBranchEndRequest{Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource"},
@@ -126,7 +128,7 @@ func TestRmBranchRollbackProcessor_SendsSuccessResponse(t *testing.T) {
 		var sent interface{}
 		processor := rmBranchRollbackProcessor{
 			getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
-			sendGrpcResponse:   func(_ int32, response interface{}) error { sent = response; return nil },
+			sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
 		}
 		err := processor.handleGrpcBranchRollback(context.Background(), message.RpcMessage{ID: 1, Body: &pb.BranchRollbackRequestProto{
 			AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource"},
@@ -140,4 +142,48 @@ func TestRmBranchRollbackProcessor_SendsSuccessResponse(t *testing.T) {
 		require.Equal(t, "xid", got.AbstractBranchEndResponse.Xid)
 		require.Equal(t, int64(7), got.AbstractBranchEndResponse.BranchId)
 	})
+}
+
+func TestRmBranchRollbackProcessor_ProcessRoutesByProtocol(t *testing.T) {
+	previous := config.GetTransportConfig()
+	t.Cleanup(func() { config.InitTransportConfig(previous) })
+
+	manager := &testResourceManager{rollbackStatus: branch.BranchStatusPhasetwoRollbacked}
+	tests := []struct {
+		name     string
+		protocol protocol.Protocol
+		body     interface{}
+		wantType interface{}
+	}{
+		{
+			name:     "seata",
+			protocol: protocol.ProtocolSEATA,
+			body: message.BranchRollbackRequest{AbstractBranchEndRequest: message.AbstractBranchEndRequest{
+				Xid: "xid", BranchId: 7, BranchType: branch.BranchTypeTCC, ResourceId: "resource",
+			}},
+			wantType: message.BranchRollbackResponse{},
+		},
+		{
+			name:     "grpc",
+			protocol: protocol.ProtocolGRPC,
+			body: &pb.BranchRollbackRequestProto{AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{
+				Xid: "xid", BranchId: 7, BranchType: pb.BranchTypeProto_TCC, ResourceId: "resource",
+			}},
+			wantType: (*pb.BranchRollbackResponseProto)(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.InitTransportConfig(&config.TransportConfig{Protocol: tt.protocol.String()})
+			var sent interface{}
+			processor := rmBranchRollbackProcessor{
+				getResourceManager: func(branch.BranchType) rm.ResourceManager { return manager },
+				sendResponse:       func(_ int32, response interface{}) error { sent = response; return nil },
+			}
+
+			require.NoError(t, processor.Process(context.Background(), message.RpcMessage{ID: 1, Body: tt.body}))
+			require.IsType(t, tt.wantType, sent)
+		})
+	}
 }


### PR DESCRIPTION
- [x] I have registered the PR changes.

## **What this PR does:**

1. Fixes error handling in RM branch commit and rollback processors. When `BranchCommit` or `BranchRollback` returns an error, the processor sends a failure response to TC instead of returning immediately and causing a timeout.
2. Covers all four transport paths: Getty/gRPC × commit/rollback.
3. Ensures the failure response contains `ResultCodeFailed`, the branch status, xid, branch ID and error message.
4. Preserves both the business error and the response-sending error with `errors.Join` when `SendAsyncResponse` fails.
5. Adds tests covering failure responses and combined business/transport errors.

## **Which issue(s) this PR fixes:**

Fixes #1156

## **Special notes for your reviewer:**

Previously, the processor returned the RM business error before sending the branch result response. This could cause TC to wait until the request timed out. The new implementation sends the protocol-level failure response first and returns an error only when response delivery fails.

The tests cover all Getty/gRPC commit and rollback paths, including xid, branch ID, branch status, result code, error message and combined error handling.

## **Does this PR introduce a user-facing change?:**
```release-note
NONE