### PR TITLE
fix(grpc): use the correct message type for global commit requests

### DIFF
--- a/changes/dev.md
+++ b/changes/dev.md
@@ -32,6 +32,7 @@
 
 ### bugfix：
 
+  - [[#1165](https://github.com/apache/incubator-seata-go/issues/1165)] fix incorrect gRPC global commit request message type
   - [[#904](https://github.com/apache/incubator-seata-go/issues/904)] fix "busy buffer" / "driver: bad connection" when a `SELECT ... FOR UPDATE` is followed by another statement under XA autoCommit, by deferring the branch commit (XA END + XA PREPARE) until the query rows are closed
   - [[#130](https://github.com/apache/incubator-seata-go/pull/130)] getty session auto close bug
   - [[#991](https://github.com/apache/incubator-seata-go/issues/991)] fix connection leaks and prevent nil pointer panic in async worker

--- a/pkg/tm/transaction/grpc/grpc_global_transaction.go
+++ b/pkg/tm/transaction/grpc/grpc_global_transaction.go
@@ -87,7 +87,7 @@ func (g *GrpcGlobalTransactionManager) Commit(ctx context.Context, gtr *tm.Globa
 	req := &pb.GlobalCommitRequestProto{
 		AbstractGlobalEndRequest: &pb.AbstractGlobalEndRequestProto{
 			AbstractTransactionRequest: &pb.AbstractTransactionRequestProto{
-				AbstractMessage: &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_GLOBAL_BEGIN},
+				AbstractMessage: &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_GLOBAL_COMMIT},
 			},
 			Xid: gtr.Xid,
 		},

--- a/pkg/tm/transaction/grpc/grpc_global_transaction_test.go
+++ b/pkg/tm/transaction/grpc/grpc_global_transaction_test.go
@@ -242,8 +242,10 @@ func TestGrpcGlobalTransactionCommitSendsGlobalCommitMessageType(t *testing.T) {
 	tm.SetGlobalTransactionManager(&grpc2.GrpcGlobalTransactionManager{})
 	tm.InitTm(tm.TmConfig{CommitRetryCount: 1})
 
+	called := false
 	patches := gomonkey.ApplyMethod(reflect.TypeOf(grpc.GetGrpcRemotingClient()), "SendSyncRequest",
 		func(_ *grpc.GrpcRemotingClient, msg interface{}) (interface{}, error) {
+			called = true
 			req, ok := msg.(*pb.GlobalCommitRequestProto)
 			assert.True(t, ok)
 			assert.Equal(t, pb.MessageTypeProto_TYPE_GLOBAL_COMMIT,
@@ -264,6 +266,7 @@ func TestGrpcGlobalTransactionCommitSendsGlobalCommitMessageType(t *testing.T) {
 
 	gtr := &tm.GlobalTransaction{TxRole: tm.Launcher, Xid: "test-xid"}
 	assert.NoError(t, tm.GetGlobalTransactionManager().Commit(context.Background(), gtr))
+	assert.True(t, called, "Commit should call SendSyncRequest")
 }
 
 func TestGrpcGlobalTransactionRollback(t *testing.T) {

--- a/pkg/tm/transaction/grpc/grpc_global_transaction_test.go
+++ b/pkg/tm/transaction/grpc/grpc_global_transaction_test.go
@@ -238,6 +238,34 @@ func TestGrpcGlobalTransactionCommit(t *testing.T) {
 	}
 }
 
+func TestGrpcGlobalTransactionCommitSendsGlobalCommitMessageType(t *testing.T) {
+	tm.SetGlobalTransactionManager(&grpc2.GrpcGlobalTransactionManager{})
+	tm.InitTm(tm.TmConfig{CommitRetryCount: 1})
+
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(grpc.GetGrpcRemotingClient()), "SendSyncRequest",
+		func(_ *grpc.GrpcRemotingClient, msg interface{}) (interface{}, error) {
+			req, ok := msg.(*pb.GlobalCommitRequestProto)
+			assert.True(t, ok)
+			assert.Equal(t, pb.MessageTypeProto_TYPE_GLOBAL_COMMIT,
+				req.GetAbstractGlobalEndRequest().GetAbstractTransactionRequest().GetAbstractMessage().GetMessageType())
+
+			return &pb.GlobalCommitResponseProto{
+				AbstractGlobalEndResponse: &pb.AbstractGlobalEndResponseProto{
+					AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
+						AbstractResultMessage: &pb.AbstractResultMessageProto{
+							AbstractMessage: &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_GLOBAL_COMMIT_RESULT},
+						},
+					},
+					GlobalStatus: pb.GlobalStatusProto_Committed,
+				},
+			}, nil
+		})
+	defer patches.Reset()
+
+	gtr := &tm.GlobalTransaction{TxRole: tm.Launcher, Xid: "test-xid"}
+	assert.NoError(t, tm.GetGlobalTransactionManager().Commit(context.Background(), gtr))
+}
+
 func TestGrpcGlobalTransactionRollback(t *testing.T) {
 	tm.SetGlobalTransactionManager(&grpc2.GrpcGlobalTransactionManager{})
 	tm.InitTm(tm.TmConfig{


### PR DESCRIPTION
## What this PR does:

1. Fixes the inner protobuf message type of gRPC global commit requests.
2. Changes `GlobalCommitRequestProto` from `TYPE_GLOBAL_BEGIN` to `TYPE_GLOBAL_COMMIT`.
3. Adds a regression test that verifies `Commit()` sends a request with `TYPE_GLOBAL_COMMIT`.

## Which issue(s) this PR fixes:

Fixes #1165

## Special notes for your reviewer:

The gRPC transaction manager constructs a `GlobalCommitRequestProto` and now sets its nested `AbstractMessage.messageType` to `TYPE_GLOBAL_COMMIT`, matching the Java client's `GlobalCommitRequest.getTypeCode()` and the Seata protocol wire format.

This change is a wire-format consistency fix. The current TC implementation routes gRPC messages using the outer `GrpcMessageProto` envelope and the protobuf `Any` type URL, and does not use this nested `messageType` for request routing. Therefore, this PR does not change user-facing transaction behavior.

The incorrect message type was introduced after v2.1.0 and has not been included in a released version.

The regression test intercepts the request passed to `SendSyncRequest` and verifies that its nested message type is `TYPE_GLOBAL_COMMIT`.

## Does this PR introduce a user-facing change?:

No. This is a protocol wire-format consistency fix and does not change user-facing behavior.

```release-note
Correct the gRPC global commit request message type for Java wire-format compatibility.