### PR TITLE
fix(grpc): align protobuf message types with Seata protocol

### DIFF
--- a/changes/dev.md
+++ b/changes/dev.md
@@ -32,6 +32,7 @@
 
 ### bugfix：
 
+  - [[#1169](https://github.com/apache/incubator-seata-go/issues/1169)] align gRPC protobuf message types with the Seata protocol
   - [[#904](https://github.com/apache/incubator-seata-go/issues/904)] fix "busy buffer" / "driver: bad connection" when a `SELECT ... FOR UPDATE` is followed by another statement under XA autoCommit, by deferring the branch commit (XA END + XA PREPARE) until the query rows are closed
   - [[#130](https://github.com/apache/incubator-seata-go/pull/130)] getty session auto close bug
   - [[#991](https://github.com/apache/incubator-seata-go/issues/991)] fix connection leaks and prevent nil pointer panic in async worker

--- a/pkg/remoting/grpc/channel_manager.go
+++ b/pkg/remoting/grpc/channel_manager.go
@@ -298,6 +298,7 @@ func (g *ChannelManager) registerTm(addr string) error {
 
 	request := &pb.RegisterTMRequestProto{
 		AbstractIdentifyRequest: &pb.AbstractIdentifyRequestProto{
+			AbstractMessage:         &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_REG_CLT},
 			Version:                 constant.SeataVersion,
 			ApplicationId:           conf.ApplicationID,
 			TransactionServiceGroup: conf.TxServiceGroup,

--- a/pkg/remoting/grpc/channel_manager_test.go
+++ b/pkg/remoting/grpc/channel_manager_test.go
@@ -18,14 +18,17 @@
 package grpc
 
 import (
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 
 	"seata.apache.org/seata-go/v2/pkg/discovery"
 	"seata.apache.org/seata-go/v2/pkg/remoting/config"
+	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/remoting/loadbalance"
 )
 
@@ -65,6 +68,28 @@ func TestChannelManagerRefreshesServerListFromRegistrySubscription(t *testing.T)
 	startMu.Lock()
 	assert.Equal(t, 2, startCount["127.0.0.1:8091"])
 	startMu.Unlock()
+}
+
+func TestChannelManagerRegisterTMUsesClientRegistrationMessageType(t *testing.T) {
+	config.InitSeataConfig(&config.SeataConfig{
+		ApplicationID:  "test-app",
+		TxServiceGroup: "test-group",
+	})
+
+	var request *pb.RegisterTMRequestProto
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(GetGrpcRemotingClient()), "SendAsyncRequest",
+		func(_ *GrpcRemotingClient, msg interface{}) error {
+			request = msg.(*pb.RegisterTMRequestProto)
+			return nil
+		})
+	defer patches.Reset()
+
+	manager := newTestChannelManager(nil)
+	assert.NoError(t, manager.registerTm("127.0.0.1:8091"))
+	if assert.NotNil(t, request) {
+		assert.Equal(t, pb.MessageTypeProto_TYPE_REG_CLT,
+			request.GetAbstractIdentifyRequest().GetAbstractMessage().GetMessageType())
+	}
 }
 
 func TestChannelManagerFallsBackToLookupWhenRegistryDoesNotSubscribe(t *testing.T) {

--- a/pkg/remoting/processor/client/rm_branch_commit_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor.go
@@ -95,8 +95,9 @@ func (f *rmBranchCommitProcessor) handleGrpcBranchCommit(ctx context.Context, rp
 		AbstractBranchEndResponse: &pb.AbstractBranchEndResponseProto{
 			AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
 				AbstractResultMessage: &pb.AbstractResultMessageProto{
-					ResultCode: resultCode,
-					Msg:        errMsg,
+					AbstractMessage: &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_BRANCH_COMMIT_RESULT},
+					ResultCode:      resultCode,
+					Msg:             errMsg,
 				},
 			},
 			Xid:          xid,

--- a/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
+++ b/pkg/remoting/processor/client/rm_branch_commit_processor_test.go
@@ -19,7 +19,11 @@ package client
 
 import (
 	"context"
+	"reflect"
 	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
 
 	"seata.apache.org/seata-go/v2/pkg/rm/tcc"
 
@@ -27,6 +31,7 @@ import (
 	"seata.apache.org/seata-go/v2/pkg/protocol/codec"
 	"seata.apache.org/seata-go/v2/pkg/protocol/message"
 	"seata.apache.org/seata-go/v2/pkg/remoting/config"
+	remotinggrpc "seata.apache.org/seata-go/v2/pkg/remoting/grpc"
 	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 )
@@ -108,4 +113,52 @@ func TestRmBranchCommitProcessor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRmBranchCommitProcessorResponseUsesCommitResultMessageType(t *testing.T) {
+	resourceManager := &testGrpcResourceManager{branchType: model2.BranchTypeTCC}
+	rm.GetRmCacheInstance().RegisterResourceManager(resourceManager)
+	defer rm.GetRmCacheInstance().UnregisterResourceManager(model2.BranchTypeTCC)
+	config.InitTransportConfig(&config.TransportConfig{Protocol: "grpc"})
+
+	var response *pb.BranchCommitResponseProto
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(remotinggrpc.GetGrpcRemotingClient()), "SendAsyncResponse",
+		func(_ *remotinggrpc.GrpcRemotingClient, _ int32, msg interface{}) error {
+			response = msg.(*pb.BranchCommitResponseProto)
+			return nil
+		})
+	defer patches.Reset()
+
+	err := (&rmBranchCommitProcessor{}).Process(context.Background(), message.RpcMessage{
+		ID:   1,
+		Type: message.RequestType(message.MessageTypeBranchCommit),
+		Body: &pb.BranchCommitRequestProto{AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{
+			Xid:        "test-xid",
+			BranchId:   1,
+			BranchType: pb.BranchTypeProto_TCC,
+		}},
+	})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, response) {
+		assert.Equal(t, pb.MessageTypeProto_TYPE_BRANCH_COMMIT_RESULT,
+			response.GetAbstractBranchEndResponse().GetAbstractTransactionResponse().GetAbstractResultMessage().GetAbstractMessage().GetMessageType())
+	}
+}
+
+type testGrpcResourceManager struct {
+	rm.ResourceManager
+	branchType model2.BranchType
+}
+
+func (m *testGrpcResourceManager) GetBranchType() model2.BranchType {
+	return m.branchType
+}
+
+func (m *testGrpcResourceManager) BranchCommit(context.Context, rm.BranchResource) (model2.BranchStatus, error) {
+	return model2.BranchStatusPhaseoneDone, nil
+}
+
+func (m *testGrpcResourceManager) BranchRollback(context.Context, rm.BranchResource) (model2.BranchStatus, error) {
+	return model2.BranchStatusPhaseoneDone, nil
 }

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor.go
@@ -95,8 +95,9 @@ func (f *rmBranchRollbackProcessor) handleGrpcBranchRollback(ctx context.Context
 		AbstractBranchEndResponse: &pb.AbstractBranchEndResponseProto{
 			AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
 				AbstractResultMessage: &pb.AbstractResultMessageProto{
-					ResultCode: resultCode,
-					Msg:        errMsg,
+					AbstractMessage: &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_BRANCH_ROLLBACK_RESULT},
+					ResultCode:      resultCode,
+					Msg:             errMsg,
 				},
 			},
 			Xid:          xid,

--- a/pkg/remoting/processor/client/rm_branch_rollback_processor_test.go
+++ b/pkg/remoting/processor/client/rm_branch_rollback_processor_test.go
@@ -19,7 +19,11 @@ package client
 
 import (
 	"context"
+	"reflect"
 	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
 
 	"seata.apache.org/seata-go/v2/pkg/rm/tcc"
 
@@ -27,6 +31,7 @@ import (
 	"seata.apache.org/seata-go/v2/pkg/protocol/codec"
 	"seata.apache.org/seata-go/v2/pkg/protocol/message"
 	"seata.apache.org/seata-go/v2/pkg/remoting/config"
+	remotinggrpc "seata.apache.org/seata-go/v2/pkg/remoting/grpc"
 	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 )
@@ -107,5 +112,36 @@ func TestRmBranchRollbackProcessor(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func TestRmBranchRollbackProcessorResponseUsesRollbackResultMessageType(t *testing.T) {
+	resourceManager := &testGrpcResourceManager{branchType: model2.BranchTypeTCC}
+	rm.GetRmCacheInstance().RegisterResourceManager(resourceManager)
+	defer rm.GetRmCacheInstance().UnregisterResourceManager(model2.BranchTypeTCC)
+	config.InitTransportConfig(&config.TransportConfig{Protocol: "grpc"})
+
+	var response *pb.BranchRollbackResponseProto
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(remotinggrpc.GetGrpcRemotingClient()), "SendAsyncResponse",
+		func(_ *remotinggrpc.GrpcRemotingClient, _ int32, msg interface{}) error {
+			response = msg.(*pb.BranchRollbackResponseProto)
+			return nil
+		})
+	defer patches.Reset()
+
+	err := (&rmBranchRollbackProcessor{}).Process(context.Background(), message.RpcMessage{
+		ID:   1,
+		Type: message.RequestType(message.MessageTypeBranchRollback),
+		Body: &pb.BranchRollbackRequestProto{AbstractBranchEndRequest: &pb.AbstractBranchEndRequestProto{
+			Xid:        "test-xid",
+			BranchId:   1,
+			BranchType: pb.BranchTypeProto_TCC,
+		}},
+	})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, response) {
+		assert.Equal(t, pb.MessageTypeProto_TYPE_BRANCH_ROLLBACK_RESULT,
+			response.GetAbstractBranchEndResponse().GetAbstractTransactionResponse().GetAbstractResultMessage().GetAbstractMessage().GetMessageType())
 	}
 }

--- a/pkg/rm/remoting/grpc/grpc_rm_remoting_test.go
+++ b/pkg/rm/remoting/grpc/grpc_rm_remoting_test.go
@@ -18,11 +18,16 @@
 package grpc
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 
+	"seata.apache.org/seata-go/v2/pkg/protocol/branch"
 	"seata.apache.org/seata-go/v2/pkg/remoting/config"
+	remotinggrpc "seata.apache.org/seata-go/v2/pkg/remoting/grpc"
+	"seata.apache.org/seata-go/v2/pkg/remoting/grpc/pb"
 	"seata.apache.org/seata-go/v2/pkg/rm"
 )
 
@@ -50,5 +55,33 @@ func TestGetGrpcRMRemotingInstance(t *testing.T) {
 			assert.NotNil(t, got)
 			assert.IsType(t, tt.wantType, got)
 		})
+	}
+}
+
+func TestGrpcRMRemotingBranchReportUsesStatusReportMessageType(t *testing.T) {
+	var request *pb.BranchReportRequestProto
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(remotinggrpc.GetGrpcRemotingClient()), "SendSyncRequest",
+		func(_ *remotinggrpc.GrpcRemotingClient, msg interface{}) (interface{}, error) {
+			request = msg.(*pb.BranchReportRequestProto)
+			return &pb.BranchReportResponseProto{
+				AbstractTransactionResponse: &pb.AbstractTransactionResponseProto{
+					AbstractResultMessage: &pb.AbstractResultMessageProto{
+						ResultCode: pb.ResultCodeProto_Success,
+					},
+				},
+			}, nil
+		})
+	defer patches.Reset()
+
+	err := (&GrpcRMRemoting{}).BranchReport(rm.BranchReportParam{
+		BranchType: branch.BranchTypeAT,
+		Xid:        "test-xid",
+		BranchId:   1,
+	})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, request) {
+		assert.Equal(t, pb.MessageTypeProto_TYPE_BRANCH_STATUS_REPORT,
+			request.GetAbstractTransactionRequest().GetAbstractMessage().GetMessageType())
 	}
 }

--- a/pkg/rm/remoting/grpc/rm_remoting.go
+++ b/pkg/rm/remoting/grpc/rm_remoting.go
@@ -62,7 +62,7 @@ func (r *GrpcRMRemoting) BranchRegister(param rm.BranchRegisterParam) (int64, er
 func (r *GrpcRMRemoting) BranchReport(param rm.BranchReportParam) error {
 	request := &pb.BranchReportRequestProto{
 		AbstractTransactionRequest: &pb.AbstractTransactionRequestProto{
-			AbstractMessage: &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_BRANCH_COMMIT},
+			AbstractMessage: &pb.AbstractMessageProto{MessageType: pb.MessageTypeProto_TYPE_BRANCH_STATUS_REPORT},
 		},
 		Xid:             param.Xid,
 		BranchId:        param.BranchId,


### PR DESCRIPTION
- [ ] I have registered the PR [changes](https://github.com/apache/incubator-seata-go/tree/master/changes).

## **What this PR does**:

Aligns the gRPC protobuf message types with the Seata protocol.

The following message types are corrected:

- TM registration uses `TYPE_REG_CLT`.
- RM branch status reporting uses `TYPE_BRANCH_STATUS_REPORT`.
- RM branch commit responses use `TYPE_BRANCH_COMMIT_RESULT`.
- RM branch rollback responses use `TYPE_BRANCH_ROLLBACK_RESULT`.

Regression tests are added to verify the message types in these requests and responses.

## **Which issue(s) this PR fixes**:

Fixes #1169

## **Special notes for your reviewer**:

The incorrect message type in the gRPC global commit request
(`TYPE_GLOBAL_BEGIN` instead of `TYPE_GLOBAL_COMMIT`) has already been
fixed separately in [PR #1166](https://github.com/apache/incubator-seata-go/pull/1166).


## **Does this PR introduce a user-facing change?**:

Yes. This is a wire-protocol compatibility fix for gRPC communication between Seata Go and Seata Server. No public API changes are introduced.

```release-note
Fix incorrect gRPC protobuf message types to ensure compatibility with the Seata protocol.